### PR TITLE
Move processing of deferred method to dedicated DeferredExecutor.

### DIFF
--- a/src/signaling/mcu_janus.go
+++ b/src/signaling/mcu_janus.go
@@ -1013,6 +1013,10 @@ retry:
 			var roomId uint64
 			handle, roomId, err = p.mcu.getOrCreateSubscriberHandle(ctx, p.publisher, p.streamType)
 			if err != nil {
+				// Reconnection didn't work, need to unregister/remove subscriber
+				// so a new object will be created if the request is retried.
+				p.mcu.unregisterClient(p)
+				p.listener.SubscriberClosed(p)
 				callback(fmt.Errorf("Already connected as subscriber for %s, error during re-joining: %s", p.streamType, err), nil)
 				return
 			}


### PR DESCRIPTION
This fixes an issue where re-joining a room after error stopped the internal processing of deferred functions.

@danxuliu please take a look to see if this fixes the issue you were having.