### PR TITLE
Add "reason" field to disinvite message.

### DIFF
--- a/src/signaling/api_signaling.go
+++ b/src/signaling/api_signaling.go
@@ -399,6 +399,17 @@ type RoomEventServerMessage struct {
 	Users   []map[string]interface{} `json:"users,omitempty"`
 }
 
+const (
+	DisinviteReasonDisinvited = "disinvited"
+	DisinviteReasonDeleted    = "deleted"
+)
+
+type RoomDisinviteEventServerMessage struct {
+	RoomEventServerMessage
+
+	Reason string `json:"reason"`
+}
+
 type RoomEventMessage struct {
 	RoomId string           `json:"roomid"`
 	Data   *json.RawMessage `json:"data,omitempty"`
@@ -414,9 +425,9 @@ type EventServerMessage struct {
 	Change []*EventServerMessageSessionEntry `json:"change,omitempty"`
 
 	// Used for target "roomlist" / "participants"
-	Invite    *RoomEventServerMessage `json:"invite,omitempty"`
-	Disinvite *RoomEventServerMessage `json:"disinvite,omitempty"`
-	Update    *RoomEventServerMessage `json:"update,omitempty"`
+	Invite    *RoomEventServerMessage          `json:"invite,omitempty"`
+	Disinvite *RoomDisinviteEventServerMessage `json:"disinvite,omitempty"`
+	Update    *RoomEventServerMessage          `json:"update,omitempty"`
 
 	// Used for target "message"
 	Message *RoomEventMessage `json:"message,omitempty"`

--- a/src/signaling/backend_server_test.go
+++ b/src/signaling/backend_server_test.go
@@ -402,6 +402,8 @@ func TestBackendServer_RoomDisinvite(t *testing.T) {
 		t.Errorf("Expected room %s, got %+v", roomId, event)
 	} else if event.Disinvite.Properties != nil {
 		t.Errorf("Room properties should be omitted, got %s", string(*event.Disinvite.Properties))
+	} else if event.Disinvite.Reason != "disinvited" {
+		t.Errorf("Reason should be disinvited, got %s", event.Disinvite.Reason)
 	}
 
 	if message, err := client.RunUntilRoomlistDisinvite(ctx); err != nil {
@@ -679,6 +681,8 @@ func TestBackendServer_RoomDelete(t *testing.T) {
 		t.Errorf("Expected room %s, got %+v", roomId, event)
 	} else if event.Disinvite.Properties != nil {
 		t.Errorf("Room properties should be omitted, got %s", string(*event.Disinvite.Properties))
+	} else if event.Disinvite.Reason != "deleted" {
+		t.Errorf("Reason should be deleted, got %s", event.Disinvite.Reason)
 	}
 
 	// TODO: Use event to wait for NATS messages.

--- a/src/signaling/testclient_test.go
+++ b/src/signaling/testclient_test.go
@@ -598,7 +598,7 @@ func (c *TestClient) RunUntilRoomlistUpdate(ctx context.Context) (*RoomEventServ
 	}
 }
 
-func checkMessageRoomlistDisinvite(message *ServerMessage) (*RoomEventServerMessage, error) {
+func checkMessageRoomlistDisinvite(message *ServerMessage) (*RoomDisinviteEventServerMessage, error) {
 	if err := checkMessageType(message, "event"); err != nil {
 		return nil, err
 	} else if message.Event.Target != "roomlist" {
@@ -610,7 +610,7 @@ func checkMessageRoomlistDisinvite(message *ServerMessage) (*RoomEventServerMess
 	return message.Event.Disinvite, nil
 }
 
-func (c *TestClient) RunUntilRoomlistDisinvite(ctx context.Context) (*RoomEventServerMessage, error) {
+func (c *TestClient) RunUntilRoomlistDisinvite(ctx context.Context) (*RoomDisinviteEventServerMessage, error) {
 	if message, err := c.RunUntilMessage(ctx); err != nil {
 		return nil, err
 	} else {


### PR DESCRIPTION
This is required so clients can differentiate between no longer being invited or the room being deleted. Fixes #25.

cc @nickvergessen