### PR TITLE
Minor reload improvements

### DIFF
--- a/src/signaling/backend_configuration.go
+++ b/src/signaling/backend_configuration.go
@@ -71,7 +71,7 @@ func NewBackendConfiguration(config *goconf.ConfigFile) (*BackendConfiguration, 
 			compat: true,
 		}
 	} else if backendIds, _ := config.GetString("backend", "backends"); backendIds != "" {
-		for host, configuredBackends := range getConfiguredHosts(config) {
+		for host, configuredBackends := range getConfiguredHosts(backendIds, config) {
 			backends[host] = append(backends[host], configuredBackends...)
 			for _, be := range configuredBackends {
 				log.Printf("Backend %s added for %s", be.id, be.url)
@@ -146,26 +146,28 @@ func (b *BackendConfiguration) UpsertHost(host string, backends []*Backend) {
 	b.backends[host] = append(b.backends[host], backends...)
 }
 
-func getConfiguredBackendIDs(config *goconf.ConfigFile) (ids map[string]bool) {
-	ids = make(map[string]bool)
+func getConfiguredBackendIDs(backendIds string) (ids []string) {
+	seen := make(map[string]bool)
 
-	if backendIds, _ := config.GetString("backend", "backends"); backendIds != "" {
-		for _, id := range strings.Split(backendIds, ",") {
-			id = strings.TrimSpace(id)
-			if id == "" {
-				continue
-			}
-
-			ids[id] = true
+	for _, id := range strings.Split(backendIds, ",") {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
 		}
+
+		if seen[id] {
+			continue
+		}
+		ids = append(ids, id)
+		seen[id] = true
 	}
 
 	return ids
 }
 
-func getConfiguredHosts(config *goconf.ConfigFile) (hosts map[string][]*Backend) {
+func getConfiguredHosts(backendIds string, config *goconf.ConfigFile) (hosts map[string][]*Backend) {
 	hosts = make(map[string][]*Backend)
-	for id := range getConfiguredBackendIDs(config) {
+	for _, id := range getConfiguredBackendIDs(backendIds) {
 		u, _ := config.GetString(id, "url")
 		if u == "" {
 			log.Printf("Backend %s is missing or incomplete, skipping", id)
@@ -199,7 +201,7 @@ func getConfiguredHosts(config *goconf.ConfigFile) (hosts map[string][]*Backend)
 
 func (b *BackendConfiguration) Reload(config *goconf.ConfigFile) {
 	if backendIds, _ := config.GetString("backend", "backends"); backendIds != "" {
-		configuredHosts := getConfiguredHosts(config)
+		configuredHosts := getConfiguredHosts(backendIds, config)
 
 		// remove backends that are no longer configured
 		for hostname := range b.backends {

--- a/src/signaling/backend_configuration.go
+++ b/src/signaling/backend_configuration.go
@@ -200,6 +200,11 @@ func getConfiguredHosts(backendIds string, config *goconf.ConfigFile) (hosts map
 }
 
 func (b *BackendConfiguration) Reload(config *goconf.ConfigFile) {
+	if b.compatBackend != nil {
+		log.Println("Old-style configuration active, reload is not supported")
+		return
+	}
+
 	if backendIds, _ := config.GetString("backend", "backends"); backendIds != "" {
 		configuredHosts := getConfiguredHosts(backendIds, config)
 

--- a/src/signaling/backend_configuration_test.go
+++ b/src/signaling/backend_configuration_test.go
@@ -189,6 +189,37 @@ func TestParseBackendIds(t *testing.T) {
 	}
 }
 
+func TestBackendReloadNoChange(t *testing.T) {
+	original_config := goconf.NewConfigFile()
+	original_config.AddOption("backend", "backends", "backend1, backend2")
+	original_config.AddOption("backend", "allowall", "false")
+	original_config.AddOption("backend1", "url", "http://domain1.invalid")
+	original_config.AddOption("backend1", "secret", string(testBackendSecret)+"-backend1")
+	original_config.AddOption("backend2", "url", "http://domain2.invalid")
+	original_config.AddOption("backend2", "secret", string(testBackendSecret)+"-backend2")
+	o_cfg, err := NewBackendConfiguration(original_config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	new_config := goconf.NewConfigFile()
+	new_config.AddOption("backend", "backends", "backend1, backend2")
+	new_config.AddOption("backend", "allowall", "false")
+	new_config.AddOption("backend1", "url", "http://domain1.invalid")
+	new_config.AddOption("backend1", "secret", string(testBackendSecret)+"-backend1")
+	new_config.AddOption("backend2", "url", "http://domain2.invalid")
+	new_config.AddOption("backend2", "secret", string(testBackendSecret)+"-backend2")
+	n_cfg, err := NewBackendConfiguration(new_config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	o_cfg.Reload(original_config)
+	if !reflect.DeepEqual(n_cfg, o_cfg) {
+		t.Error("BackendConfiguration should be equal after Reload")
+	}
+}
+
 func TestBackendReloadChangeExistingURL(t *testing.T) {
 	original_config := goconf.NewConfigFile()
 	original_config.AddOption("backend", "backends", "backend1, backend2")
@@ -291,13 +322,13 @@ func TestBackendReloadAddBackend(t *testing.T) {
 	}
 }
 
-func TestBackendReloadRemove(t *testing.T) {
+func TestBackendReloadRemoveHost(t *testing.T) {
 	original_config := goconf.NewConfigFile()
 	original_config.AddOption("backend", "backends", "backend1, backend2")
 	original_config.AddOption("backend", "allowall", "false")
 	original_config.AddOption("backend1", "url", "http://domain1.invalid")
 	original_config.AddOption("backend1", "secret", string(testBackendSecret)+"-backend1")
-	original_config.AddOption("backend2", "url", "http://domain1.invalid")
+	original_config.AddOption("backend2", "url", "http://domain2.invalid")
 	original_config.AddOption("backend2", "secret", string(testBackendSecret)+"-backend2")
 	o_cfg, err := NewBackendConfiguration(original_config)
 	if err != nil {
@@ -314,6 +345,41 @@ func TestBackendReloadRemove(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	original_config.RemoveOption("backend", "backends")
+	original_config.AddOption("backend", "backends", "backend1")
+	original_config.RemoveSection("backend2")
+
+	o_cfg.Reload(original_config)
+	if !reflect.DeepEqual(n_cfg, o_cfg) {
+		t.Error("BackendConfiguration should be equal after Reload")
+	}
+}
+
+func TestBackendReloadRemoveBackendFromSharedHost(t *testing.T) {
+	original_config := goconf.NewConfigFile()
+	original_config.AddOption("backend", "backends", "backend1, backend2")
+	original_config.AddOption("backend", "allowall", "false")
+	original_config.AddOption("backend1", "url", "http://domain1.invalid/foo/")
+	original_config.AddOption("backend1", "secret", string(testBackendSecret)+"-backend1")
+	original_config.AddOption("backend2", "url", "http://domain1.invalid/bar/")
+	original_config.AddOption("backend2", "secret", string(testBackendSecret)+"-backend2")
+	o_cfg, err := NewBackendConfiguration(original_config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	new_config := goconf.NewConfigFile()
+	new_config.AddOption("backend", "backends", "backend1")
+	new_config.AddOption("backend", "allowall", "false")
+	new_config.AddOption("backend1", "url", "http://domain1.invalid/foo/")
+	new_config.AddOption("backend1", "secret", string(testBackendSecret)+"-backend1")
+	n_cfg, err := NewBackendConfiguration(new_config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	original_config.RemoveOption("backend", "backends")
+	original_config.AddOption("backend", "backends", "backend1")
 	original_config.RemoveSection("backend2")
 
 	o_cfg.Reload(original_config)

--- a/src/signaling/backend_configuration_test.go
+++ b/src/signaling/backend_configuration_test.go
@@ -165,6 +165,30 @@ func TestIsUrlAllowed_AllowAll(t *testing.T) {
 	testUrls(t, cfg, valid_urls, invalid_urls)
 }
 
+type ParseBackendIdsTestcase struct {
+	s   string
+	ids []string
+}
+
+func TestParseBackendIds(t *testing.T) {
+	testcases := []ParseBackendIdsTestcase{
+		ParseBackendIdsTestcase{"", nil},
+		ParseBackendIdsTestcase{"backend1", []string{"backend1"}},
+		ParseBackendIdsTestcase{" backend1 ", []string{"backend1"}},
+		ParseBackendIdsTestcase{"backend1,", []string{"backend1"}},
+		ParseBackendIdsTestcase{"backend1,backend1", []string{"backend1"}},
+		ParseBackendIdsTestcase{"backend1, backend2", []string{"backend1", "backend2"}},
+		ParseBackendIdsTestcase{"backend1,backend2, backend1", []string{"backend1", "backend2"}},
+	}
+
+	for _, test := range testcases {
+		ids := getConfiguredBackendIDs(test.s)
+		if !reflect.DeepEqual(ids, test.ids) {
+			t.Errorf("List of ids differs, expected %+v, got %+v", test.ids, ids)
+		}
+	}
+}
+
 func TestBackendReloadChangeExistingURL(t *testing.T) {
 	original_config := goconf.NewConfigFile()
 	original_config.AddOption("backend", "backends", "backend1, backend2")


### PR DESCRIPTION
Follow-up on #52 

- Always load backends in the order they are configured.
- Don't allow reload with old-style backend configurations.
- Update reload tests.
- Log what backends are added/changed/removed on reload.

cc @membero @jkahrs