### PR TITLE
Add '--full-trickle' to janus command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     restart: unless-stopped
   janus:
     build: docker/janus
-    command: ["janus"]
+    command: ["janus", "--full-trickle"]
     network_mode: host
     restart: unless-stopped
   coturn:


### PR DESCRIPTION
The signaling server warns about the missing '--full-trickle' parameter, therefore adding this.