### PR TITLE
Align 64-bit members that are accessed atomically.

### DIFF
--- a/src/proxy/proxy_server.go
+++ b/src/proxy/proxy_server.go
@@ -81,6 +81,9 @@ var (
 )
 
 type ProxyServer struct {
+	// 64-bit members that are accessed atomically must be 64-bit aligned.
+	load int64
+
 	version string
 	country string
 
@@ -88,7 +91,6 @@ type ProxyServer struct {
 	nats    signaling.NatsClient
 	mcu     signaling.Mcu
 	stopped uint32
-	load    int64
 
 	shutdownChannel   chan bool
 	shutdownScheduled uint32

--- a/src/proxy/proxy_session.go
+++ b/src/proxy/proxy_session.go
@@ -37,10 +37,12 @@ const (
 )
 
 type ProxySession struct {
-	proxy    *ProxyServer
-	id       string
-	sid      uint64
+	// 64-bit members that are accessed atomically must be 64-bit aligned.
 	lastUsed int64
+
+	proxy *ProxyServer
+	id    string
+	sid   uint64
 
 	clientLock      sync.Mutex
 	client          *ProxyClient

--- a/src/signaling/hub.go
+++ b/src/signaling/hub.go
@@ -96,6 +96,9 @@ const (
 )
 
 type Hub struct {
+	// 64-bit members that are accessed atomically must be 64-bit aligned.
+	sid uint64
+
 	nats         NatsClient
 	upgrader     websocket.Upgrader
 	cookie       *securecookie.SecureCookie
@@ -113,7 +116,6 @@ type Hub struct {
 	mu sync.RWMutex
 	ru sync.RWMutex
 
-	sid      uint64
 	clients  map[uint64]*Client
 	sessions map[uint64]Session
 	rooms    map[string]*Room

--- a/src/signaling/mcu_janus.go
+++ b/src/signaling/mcu_janus.go
@@ -136,6 +136,9 @@ type clientInterface interface {
 }
 
 type mcuJanus struct {
+	// 64-bit members that are accessed atomically must be 64-bit aligned.
+	clientId uint64
+
 	url  string
 	mu   sync.Mutex
 	nats NatsClient
@@ -150,7 +153,6 @@ type mcuJanus struct {
 
 	closeChan chan bool
 
-	clientId  uint64
 	muClients sync.Mutex
 	clients   map[clientInterface]bool
 

--- a/src/signaling/mcu_proxy.go
+++ b/src/signaling/mcu_proxy.go
@@ -259,6 +259,11 @@ func (s *mcuProxySubscriber) ProcessEvent(msg *EventProxyServerMessage) {
 }
 
 type mcuProxyConnection struct {
+	// 64-bit members that are accessed atomically must be 64-bit aligned.
+	reconnectInterval int64
+	msgId             int64
+	load              int64
+
 	proxy  *mcuProxy
 	rawUrl string
 	url    *url.URL
@@ -270,15 +275,12 @@ type mcuProxyConnection struct {
 	conn       *websocket.Conn
 
 	connectedSince    time.Time
-	reconnectInterval int64
 	reconnectTimer    *time.Timer
 	shutdownScheduled uint32
 	closeScheduled    uint32
 
-	msgId      int64
 	helloMsgId string
 	sessionId  string
-	load       int64
 	country    atomic.Value
 
 	callbacks map[string]func(*ProxyServerMessage)
@@ -959,6 +961,10 @@ func (c *mcuProxyConnection) newSubscriber(ctx context.Context, listener McuList
 }
 
 type mcuProxy struct {
+	// 64-bit members that are accessed atomically must be 64-bit aligned.
+	connRequests int64
+	nextSort     int64
+
 	tokenId  string
 	tokenKey *rsa.PrivateKey
 
@@ -972,8 +978,6 @@ type mcuProxy struct {
 	connections    []*mcuProxyConnection
 	connectionsMap map[string]*mcuProxyConnection
 	connectionsMu  sync.RWMutex
-	connRequests   int64
-	nextSort       int64
 	proxyTimeout   time.Duration
 
 	mu         sync.RWMutex


### PR DESCRIPTION
This is required on some architectures as per https://golang.org/pkg/sync/atomic/#pkg-note-BUG

Fixes #71