### PR TITLE
Make the response from the client auth backend OCS compliant

### DIFF
--- a/src/client/main.go
+++ b/src/client/main.go
@@ -209,6 +209,9 @@ func (c *SignalingClient) processMessage(message *signaling.ServerMessage) {
 	case "bye":
 		log.Printf("Received bye: %+v\n", message.Bye)
 		c.Close()
+	case "error":
+		log.Printf("Received error: %+v\n", message.Error)
+		c.Close()
 	default:
 		log.Printf("Unsupported message type: %+v\n", *message)
 	}

--- a/src/client/main.go
+++ b/src/client/main.go
@@ -456,9 +456,22 @@ func registerAuthHandler(router *mux.Router) {
 			return
 		}
 
+		rawdata := json.RawMessage(data)
+		payload := &signaling.OcsResponse{
+			Ocs: &signaling.OcsBody{
+				Data: &rawdata,
+			},
+		}
+
+		jsonpayload, err := payload.MarshalJSON()
+		if err != nil {
+			log.Println(err)
+			return
+		}
+
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		w.Write(data)
+		w.Write(jsonpayload)
 	})
 }
 


### PR DESCRIPTION
Fixes #70 

The signaling backend expects the auth backend to reply with an OCS compliant structure. The provided client did not reply with such as response and triggered an `Incomplete OCS response` error in the signaling backend. 