### PR TITLE
Support defining maximum bandwidths at diferent levels.

### DIFF
--- a/api_proxy.go
+++ b/api_proxy.go
@@ -174,6 +174,7 @@ type CommandProxyClientMessage struct {
 	StreamType  string `json:"streamType,omitempty"`
 	PublisherId string `json:"publisherId,omitempty"`
 	ClientId    string `json:"clientId,omitempty"`
+	Bitrate     int    `json:"bitrate,omitempty"`
 }
 
 func (m *CommandProxyClientMessage) CheckValid() error {

--- a/backend_configuration.go
+++ b/backend_configuration.go
@@ -41,6 +41,9 @@ type Backend struct {
 	secret []byte
 	compat bool
 
+	maxStreamBitrate int
+	maxScreenBitrate int
+
 	sessionLimit uint64
 	sessionsLock sync.Mutex
 	sessions     map[string]bool
@@ -269,10 +272,22 @@ func getConfiguredHosts(backendIds string, config *goconf.ConfigFile) (hosts map
 			log.Printf("Backend %s allows a maximum of %d sessions", id, sessionLimit)
 		}
 
+		maxStreamBitrate, err := config.GetInt(id, "maxstreambitrate")
+		if err != nil || maxStreamBitrate < 0 {
+			maxStreamBitrate = 0
+		}
+		maxScreenBitrate, err := config.GetInt(id, "maxscreenbitrate")
+		if err != nil || maxScreenBitrate < 0 {
+			maxScreenBitrate = 0
+		}
+
 		hosts[parsed.Host] = append(hosts[parsed.Host], &Backend{
 			id:     id,
 			url:    u,
 			secret: []byte(secret),
+
+			maxStreamBitrate: maxStreamBitrate,
+			maxScreenBitrate: maxScreenBitrate,
 
 			sessionLimit: uint64(sessionLimit),
 		})

--- a/clientsession.go
+++ b/clientsession.go
@@ -627,8 +627,17 @@ func (s *ClientSession) GetOrCreatePublisher(ctx context.Context, mcu Mcu, strea
 	if !found {
 		client := s.getClientUnlocked()
 		s.mu.Unlock()
+
+		var bitrate int
+		if backend := s.Backend(); backend != nil {
+			if streamType == streamTypeScreen {
+				bitrate = backend.maxScreenBitrate
+			} else {
+				bitrate = backend.maxStreamBitrate
+			}
+		}
 		var err error
-		publisher, err = mcu.NewPublisher(ctx, s, s.PublicId(), streamType, client)
+		publisher, err = mcu.NewPublisher(ctx, s, s.PublicId(), streamType, bitrate, client)
 		s.mu.Lock()
 		if err != nil {
 			return nil, err

--- a/mcu_common.go
+++ b/mcu_common.go
@@ -63,7 +63,7 @@ type Mcu interface {
 
 	GetStats() interface{}
 
-	NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, initiator McuInitiator) (McuPublisher, error)
+	NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, bitrate int, initiator McuInitiator) (McuPublisher, error)
 	NewSubscriber(ctx context.Context, listener McuListener, publisher string, streamType string) (McuSubscriber, error)
 }
 

--- a/mcu_test.go
+++ b/mcu_test.go
@@ -55,7 +55,7 @@ func (m *TestMCU) GetStats() interface{} {
 	return nil
 }
 
-func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, initiator McuInitiator) (McuPublisher, error) {
+func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, bitrate int, initiator McuInitiator) (McuPublisher, error) {
 	return nil, fmt.Errorf("Not implemented")
 }
 

--- a/proxy/proxy_server.go
+++ b/proxy/proxy_server.go
@@ -630,7 +630,7 @@ func (s *ProxyServer) processCommand(ctx context.Context, client *ProxyClient, s
 		}
 
 		id := uuid.New().String()
-		publisher, err := s.mcu.NewPublisher(ctx, session, id, cmd.StreamType, &emptyInitiator{})
+		publisher, err := s.mcu.NewPublisher(ctx, session, id, cmd.StreamType, cmd.Bitrate, &emptyInitiator{})
 		if err == context.DeadlineExceeded {
 			log.Printf("Timeout while creating %s publisher %s for %s", cmd.StreamType, id, session.PublicId())
 			session.sendMessage(message.NewErrorServerMessage(TimeoutCreatingPublisher))

--- a/server.conf.in
+++ b/server.conf.in
@@ -86,6 +86,14 @@ connectionsperhost = 8
 # Omit or set to 0 to not limit the number of sessions.
 #sessionlimit = 10
 
+# The maximum bitrate per publishing stream (in bits per second).
+# Defaults to the maximum bitrate configured for the proxy / MCU.
+#maxstreambitrate = 1048576
+
+# The maximum bitrate per screensharing stream (in bits per second).
+# Defaults to the maximum bitrate configured for the proxy / MCU.
+#maxscreenbitrate = 2097152
+
 #[another-backend]
 # URL of the Nextcloud instance
 #url = https://cloud.otherdomain.invalid
@@ -110,14 +118,16 @@ connectionsperhost = 8
 # For type "proxy": a space-separated list of proxy URLs to connect to.
 #url =
 
-# For type "janus": the maximum bitrate per publishing stream (in bits per
-# second).
+# The maximum bitrate per publishing stream (in bits per second).
 # Defaults to 1 mbit/sec.
+# For type "proxy": will be capped to the maximum bitrate configured at the
+# proxy server that is used.
 #maxstreambitrate = 1048576
 
-# For type "janus": the maximum bitrate per screensharing stream (in bits per
-# second).
+# The maximum bitrate per screensharing stream (in bits per second).
 # Default is 2 mbit/sec.
+# For type "proxy": will be capped to the maximum bitrate configured at the
+# proxy server that is used.
 #maxscreenbitrate = 2097152
 
 # For type "proxy": timeout in seconds for requests to the proxy server.


### PR DESCRIPTION
- Individually for each backend.
- For the proxy client (i.e. signaling server using cluster of proxies).
- For the proxy server / MCU.

The smallest bandwidth configured will be used, e.g. if a backend has a
larger limit than the MCU assigned for the stream, the limit of the MCU
server will be used.