### PR TITLE
fix(docs): update config example for Apache proxy config

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ interface on port `8080` below):
 
         RewriteEngine On
         # Websocket connections from the clients.
-        RewriteRule ^/standalone-signaling/spreed$ - [L]
+        RewriteRule ^/standalone-signaling/spreed/$ - [L]
         # Backend connections from Nextcloud.
         RewriteRule ^/standalone-signaling/api/(.*) http://127.0.0.1:8080/api/$1 [L,P]
 


### PR DESCRIPTION
Without the trailing slash, the config will not work. Instead the Nextcloud talk client will receive an error 400.

See also https://help.nextcloud.com/t/error-400-when-trying-to-access-high-performance-backend-signaling/106999/2