### PR TITLE
Stop using legacy ptype "listener".

### DIFF
--- a/src/signaling/mcu_janus.go
+++ b/src/signaling/mcu_janus.go
@@ -1059,7 +1059,7 @@ func (p *mcuJanusSubscriber) joinRoom(ctx context.Context, callback func(error, 
 retry:
 	join_msg := map[string]interface{}{
 		"request": "join",
-		"ptype":   "listener",
+		"ptype":   "subscriber",
 		"room":    p.roomId,
 		"feed":    streamTypeUserIds[p.streamType],
 	}


### PR DESCRIPTION
Removes warning in Janus:
```
[WARN] Subscriber is using the legacy 'listener' ptype
```