### PR TITLE
[Fix][Documentation] Fix Caddy v2 Example Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ myserver.domain.invalid {
 myserver.domain.invalid {
   route /standalone-signaling/* {
     uri strip_prefix /standalone-signaling
-    reverse_proxy /standalone-signaling/* http://127.0.0.1:8080
+    reverse_proxy /* http://127.0.0.1:8080
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ myserver.domain.invalid {
 myserver.domain.invalid {
   route /standalone-signaling/* {
     uri strip_prefix /standalone-signaling
-    reverse_proxy /* http://127.0.0.1:8080
+    reverse_proxy http://127.0.0.1:8080
   }
 }
 ```


### PR DESCRIPTION
There is a small but significant error in the Caddy v2 example configuration. The reverse proxy directive applies to the new path not to the old path hence you need to also strip the prefix from the reverse proxy directive in order for it to work.