### PR TITLE
Make client message processing asynchronous.

### DIFF
--- a/client.go
+++ b/client.go
@@ -139,6 +139,7 @@ func (c *Client) SetConn(conn *websocket.Conn, remoteAddress string) {
 	c.conn = conn
 	c.addr = remoteAddress
 	c.closeChan = make(chan bool, 1)
+	c.messageChan = make(chan *bytes.Buffer, 16)
 	c.OnLookupCountry = func(client *Client) string { return unknownCountry }
 	c.OnClosed = func(client *Client) {}
 	c.OnMessageReceived = func(client *Client, data []byte) {}

--- a/clientsession.go
+++ b/clientsession.go
@@ -559,6 +559,14 @@ func (s *ClientSession) sendMessageUnlocked(message *ServerMessage) bool {
 	return true
 }
 
+func (s *ClientSession) SendError(e *Error) bool {
+	message := &ServerMessage{
+		Type:  "error",
+		Error: e,
+	}
+	return s.SendMessage(message)
+}
+
 func (s *ClientSession) SendMessage(message *ServerMessage) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -822,7 +830,7 @@ func (s *ClientSession) NotifySessionResumed(client *Client) {
 	if len(s.pendingClientMessages) == 0 {
 		s.mu.Unlock()
 		if room := s.GetRoom(); room != nil {
-			room.NotifySessionResumed(client)
+			room.NotifySessionResumed(s)
 		}
 		return
 	}
@@ -841,7 +849,7 @@ func (s *ClientSession) NotifySessionResumed(client *Client) {
 	if !hasPendingParticipantsUpdate {
 		// Only need to send initial participants list update if none was part of the pending messages.
 		if room := s.GetRoom(); room != nil {
-			room.NotifySessionResumed(client)
+			room.NotifySessionResumed(s)
 		}
 	}
 }

--- a/hub.go
+++ b/hub.go
@@ -740,7 +740,7 @@ func (h *Hub) processRegister(client *Client, message *ClientMessage, backend *B
 
 	h.setDecodedSessionId(privateSessionId, privateSessionName, sessionIdData)
 	h.setDecodedSessionId(publicSessionId, publicSessionName, sessionIdData)
-	h.sendHelloResponse(client, message, session)
+	h.sendHelloResponse(session, message)
 }
 
 func (h *Hub) processUnregister(client *Client) *ClientSession {
@@ -816,7 +816,7 @@ func (h *Hub) processMessage(client *Client, data []byte) {
 	}
 }
 
-func (h *Hub) sendHelloResponse(client *Client, message *ClientMessage, session *ClientSession) bool {
+func (h *Hub) sendHelloResponse(session *ClientSession, message *ClientMessage) bool {
 	response := &ServerMessage{
 		Id:   message.Id,
 		Type: "hello",
@@ -828,7 +828,7 @@ func (h *Hub) sendHelloResponse(client *Client, message *ClientMessage, session 
 			Server:    h.GetServerInfo(session),
 		},
 	}
-	return client.SendMessage(response)
+	return session.SendMessage(response)
 }
 
 func (h *Hub) processHello(client *Client, message *ClientMessage) {
@@ -875,7 +875,7 @@ func (h *Hub) processHello(client *Client, message *ClientMessage) {
 
 		log.Printf("Resume session from %s in %s (%s) %s (private=%s)", client.RemoteAddr(), client.Country(), client.UserAgent(), session.PublicId(), session.PrivateId())
 
-		h.sendHelloResponse(client, message, clientSession)
+		h.sendHelloResponse(clientSession, message)
 		clientSession.NotifySessionResumed(client)
 		return
 	}

--- a/hub_test.go
+++ b/hub_test.go
@@ -254,7 +254,10 @@ func processRoomRequest(t *testing.T, w http.ResponseWriter, r *http.Request, re
 		t.Fatalf("Expected an room backend request, got %+v", request)
 	}
 
-	if request.Room.RoomId == "test-room-takeover-room-session" {
+	switch request.Room.RoomId {
+	case "test-room-slow":
+		time.Sleep(100 * time.Millisecond)
+	case "test-room-takeover-room-session":
 		// Additional checks for testcase "TestClientTakeoverRoomSession"
 		if request.Room.Action == "leave" && request.Room.UserId == "test-userid1" {
 			t.Errorf("Should not receive \"leave\" event for first user, received %+v", request.Room)
@@ -1747,6 +1750,95 @@ func TestJoinMultiple(t *testing.T) {
 		t.Error(err)
 	}
 
+	if room, err := client2.JoinRoom(ctx, ""); err != nil {
+		t.Fatal(err)
+	} else if room.Room.RoomId != "" {
+		t.Fatalf("Expected empty room, got %s", room.Room.RoomId)
+	}
+}
+
+func TestJoinRoomSwitchClient(t *testing.T) {
+	hub, _, _, server, shutdown := CreateHubForTest(t)
+	defer shutdown()
+
+	client := NewTestClient(t, server, hub)
+	defer client.CloseWithBye()
+
+	if err := client.SendHello(testDefaultUserId); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	hello, err := client.RunUntilHello(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Join room by id.
+	roomId := "test-room-slow"
+	msg := &ClientMessage{
+		Id:   "ABCD",
+		Type: "room",
+		Room: &RoomClientMessage{
+			RoomId:    roomId,
+			SessionId: roomId + "-" + hello.Hello.SessionId,
+		},
+	}
+	if err := client.WriteJSON(msg); err != nil {
+		t.Fatal(err)
+	}
+	// Wait a bit to make sure request is sent before closing client.
+	time.Sleep(1 * time.Millisecond)
+	client.Close()
+	if err := client.WaitForClientRemoved(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// The client needs some time to reconnect.
+	time.Sleep(200 * time.Millisecond)
+
+	client2 := NewTestClient(t, server, hub)
+	defer client2.CloseWithBye()
+	if err := client2.SendHelloResume(hello.Hello.ResumeId); err != nil {
+		t.Fatal(err)
+	}
+	hello2, err := client2.RunUntilHello(ctx)
+	if err != nil {
+		t.Error(err)
+	} else {
+		if hello2.Hello.UserId != testDefaultUserId {
+			t.Errorf("Expected \"%s\", got %+v", testDefaultUserId, hello2.Hello)
+		}
+		if hello2.Hello.SessionId != hello.Hello.SessionId {
+			t.Errorf("Expected session id %s, got %+v", hello.Hello.SessionId, hello2.Hello)
+		}
+		if hello2.Hello.ResumeId != hello.Hello.ResumeId {
+			t.Errorf("Expected resume id %s, got %+v", hello.Hello.ResumeId, hello2.Hello)
+		}
+	}
+
+	room, err := client2.RunUntilMessage(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := checkUnexpectedClose(err); err != nil {
+		t.Fatal(err)
+	}
+	if err := checkMessageType(room, "room"); err != nil {
+		t.Fatal(err)
+	}
+	if room.Room.RoomId != roomId {
+		t.Fatalf("Expected room %s, got %s", roomId, room.Room.RoomId)
+	}
+
+	// We will receive a "joined" event.
+	if err := client2.RunUntilJoined(ctx, hello.Hello); err != nil {
+		t.Error(err)
+	}
+
+	// Leave room.
 	if room, err := client2.JoinRoom(ctx, ""); err != nil {
 		t.Fatal(err)
 	} else if room.Room.RoomId != "" {

--- a/hub_test.go
+++ b/hub_test.go
@@ -1933,6 +1933,9 @@ func TestClientMessageToSessionIdWhileDisconnected(t *testing.T) {
 	client1.SendMessage(recipient2, data1) // nolint
 	client1.SendMessage(recipient2, data1) // nolint
 
+	// Simulate some time until client resumes the session.
+	time.Sleep(10 * time.Millisecond)
+
 	client2 = NewTestClient(t, server, hub)
 	defer client2.CloseWithBye()
 	if err := client2.SendHelloResume(hello2.Hello.ResumeId); err != nil {

--- a/natsclient_loopback.go
+++ b/natsclient_loopback.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/nats-io/nats.go"
 )
@@ -95,6 +96,9 @@ func (s *loopbackNatsSubscription) run() {
 			msg := s.incoming[0]
 			s.incoming = s.incoming[1:]
 			s.cond.L.Unlock()
+			// A "real" NATS server would take some time to process the request,
+			// simulate this by sleeping a tiny bit.
+			time.Sleep(time.Millisecond)
 			s.ch <- msg
 			s.cond.L.Lock()
 		}

--- a/room.go
+++ b/room.go
@@ -590,13 +590,13 @@ func (r *Room) getParticipantsUpdateMessage(users []map[string]interface{}) *Ser
 	return message
 }
 
-func (r *Room) NotifySessionResumed(client *Client) {
+func (r *Room) NotifySessionResumed(session *ClientSession) {
 	message := r.getParticipantsUpdateMessage(r.users)
 	if len(message.Event.Update.Users) == 0 {
 		return
 	}
 
-	client.SendMessage(message)
+	session.SendMessage(message)
 }
 
 func (r *Room) NotifySessionChanged(session Session) {


### PR DESCRIPTION
This helps in detecting clients that disconnect while a backend request for them is still active (e.g. joining a room).