### PR TITLE
Remove NATS notifications for Janus publishers

### DIFF
--- a/notifier.go
+++ b/notifier.go
@@ -1,0 +1,100 @@
+/**
+ * Standalone signaling server for the Nextcloud Spreed app.
+ * Copyright (C) 2021 struktur AG
+ *
+ * @author Joachim Bauch <bauch@struktur.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package signaling
+
+import (
+	"context"
+	"sync"
+)
+
+type Waiter struct {
+	key string
+	ch  chan bool
+}
+
+func (w *Waiter) Wait(ctx context.Context) error {
+	select {
+	case <-w.ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type Notifier struct {
+	sync.Mutex
+
+	waiters map[string]*Waiter
+}
+
+func (n *Notifier) NewWaiter(key string) *Waiter {
+	n.Lock()
+	defer n.Unlock()
+
+	_, found := n.waiters[key]
+	if found {
+		panic("already waiting")
+	}
+
+	waiter := &Waiter{
+		key: key,
+		ch:  make(chan bool, 1),
+	}
+	if n.waiters == nil {
+		n.waiters = make(map[string]*Waiter)
+	}
+	n.waiters[key] = waiter
+	return waiter
+}
+
+func (n *Notifier) Reset() {
+	n.Lock()
+	defer n.Unlock()
+
+	for _, w := range n.waiters {
+		close(w.ch)
+	}
+	n.waiters = nil
+}
+
+func (n *Notifier) Release(w *Waiter) {
+	n.Lock()
+	defer n.Unlock()
+
+	if _, found := n.waiters[w.key]; found {
+		delete(n.waiters, w.key)
+		close(w.ch)
+	}
+}
+
+func (n *Notifier) Notify(key string) {
+	n.Lock()
+	defer n.Unlock()
+
+	if w, found := n.waiters[key]; found {
+		select {
+		case w.ch <- true:
+		default:
+			// Ignore, already notified
+		}
+	}
+}

--- a/notifier_test.go
+++ b/notifier_test.go
@@ -1,0 +1,120 @@
+/**
+ * Standalone signaling server for the Nextcloud Spreed app.
+ * Copyright (C) 2021 struktur AG
+ *
+ * @author Joachim Bauch <bauch@struktur.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package signaling
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNotifierNoWaiter(t *testing.T) {
+	var notifier Notifier
+
+	// Notifications can be sent even if no waiter exists.
+	notifier.Notify("foo")
+}
+
+func TestNotifierSimple(t *testing.T) {
+	var notifier Notifier
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	waiter := notifier.NewWaiter("foo")
+	defer notifier.Release(waiter)
+
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := waiter.Wait(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	notifier.Notify("foo")
+	wg.Wait()
+}
+
+func TestNotifierMultiNotify(t *testing.T) {
+	var notifier Notifier
+
+	waiter := notifier.NewWaiter("foo")
+	defer notifier.Release(waiter)
+
+	notifier.Notify("foo")
+	// The second notification will be ignored while the first is still pending.
+	notifier.Notify("foo")
+}
+
+func TestNotifierWaitClosed(t *testing.T) {
+	var notifier Notifier
+
+	waiter := notifier.NewWaiter("foo")
+	notifier.Release(waiter)
+
+	if err := waiter.Wait(context.Background()); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestNotifierResetWillNotify(t *testing.T) {
+	var notifier Notifier
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	waiter := notifier.NewWaiter("foo")
+	defer notifier.Release(waiter)
+
+	go func() {
+		defer wg.Done()
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := waiter.Wait(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	notifier.Reset()
+	wg.Wait()
+}
+
+func TestNotifierDuplicate(t *testing.T) {
+	var notifier Notifier
+
+	waiter := notifier.NewWaiter("foo")
+	defer notifier.Release(waiter)
+
+	defer func() {
+		if e := recover(); e != nil {
+			if e.(string) != "already waiting" {
+				t.Errorf("Expected error about already waiting, got %+v", e)
+			}
+		}
+	}()
+
+	// Creating a waiter for an existing key will panic.
+	notifier.NewWaiter("foo")
+}

--- a/proxy.conf.in
+++ b/proxy.conf.in
@@ -20,13 +20,6 @@
 # - etcd: Token information are retrieved from an etcd cluster (see below).
 tokentype = static
 
-[nats]
-# Url of NATS backend to use. This can also be a list of URLs to connect to
-# multiple backends. For local development, this can be set to ":loopback:"
-# to process NATS messages internally instead of sending them through an
-# external NATS backend.
-#url = nats://localhost:4222
-
 [tokens]
 # For token type "static": Mapping of <tokenid> = <publickey> of signaling
 # servers allowed to connect.

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -36,9 +36,6 @@ import (
 
 	"github.com/dlintw/goconf"
 	"github.com/gorilla/mux"
-	"github.com/nats-io/nats.go"
-
-	signaling "github.com/strukturag/nextcloud-spreed-signaling"
 )
 
 var (
@@ -81,19 +78,9 @@ func main() {
 	runtime.GOMAXPROCS(cpus)
 	log.Printf("Using a maximum of %d CPUs\n", cpus)
 
-	natsUrl, _ := config.GetString("nats", "url")
-	if natsUrl == "" {
-		natsUrl = nats.DefaultURL
-	}
-
-	nats, err := signaling.NewNatsClient(natsUrl)
-	if err != nil {
-		log.Fatal("Could not create NATS client: ", err)
-	}
-
 	r := mux.NewRouter()
 
-	proxy, err := NewProxyServer(r, version, config, nats)
+	proxy, err := NewProxyServer(r, version, config)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/proxy/proxy_server.go
+++ b/proxy/proxy_server.go
@@ -88,7 +88,6 @@ type ProxyServer struct {
 	country string
 
 	url     string
-	nats    signaling.NatsClient
 	mcu     signaling.Mcu
 	stopped uint32
 
@@ -110,7 +109,7 @@ type ProxyServer struct {
 	clientsLock sync.RWMutex
 }
 
-func NewProxyServer(r *mux.Router, version string, config *goconf.ConfigFile, nats signaling.NatsClient) (*ProxyServer, error) {
+func NewProxyServer(r *mux.Router, version string, config *goconf.ConfigFile) (*ProxyServer, error) {
 	hashKey := make([]byte, 64)
 	if _, err := rand.Read(hashKey); err != nil {
 		return nil, fmt.Errorf("Could not generate random hash key: %s", err)
@@ -171,8 +170,6 @@ func NewProxyServer(r *mux.Router, version string, config *goconf.ConfigFile, na
 	result := &ProxyServer{
 		version: version,
 		country: country,
-
-		nats: nats,
 
 		shutdownChannel: make(chan bool, 1),
 
@@ -238,7 +235,7 @@ func (s *ProxyServer) Start(config *goconf.ConfigFile) error {
 	for {
 		switch mcuType {
 		case signaling.McuTypeJanus:
-			mcu, err = signaling.NewMcuJanus(s.url, config, s.nats)
+			mcu, err = signaling.NewMcuJanus(s.url, config)
 		default:
 			return fmt.Errorf("Unsupported MCU type: %s", mcuType)
 		}

--- a/server/main.go
+++ b/server/main.go
@@ -175,7 +175,7 @@ func main() {
 		for {
 			switch mcuType {
 			case signaling.McuTypeJanus:
-				mcu, err = signaling.NewMcuJanus(mcuUrl, config, nats)
+				mcu, err = signaling.NewMcuJanus(mcuUrl, config)
 			case signaling.McuTypeProxy:
 				mcu, err = signaling.NewMcuProxy(config)
 			default:


### PR DESCRIPTION
Assume one Janus server is only used by one signaling server / -proxy.

With that, we can notify publisher events locally instead of through NATS and can remove code that looks up publisher rooms by their ids on Janus.