### PR TITLE
adjust easyjson for multiarch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,12 @@ ifneq ($(COUNT),)
 TESTARGS := $(TESTARGS) -count $(COUNT)
 endif
 
+ifeq ($(GOARCH), amd64)
+VENDORBIN := $(CURDIR)/vendor/bin
+else
+VENDORBIN := $(CURDIR)/vendor/bin/$(GOOS)_$(GOARCH)
+endif
+
 hook:
 	[ ! -d "$(CURDIR)/.git/hooks" ] || ln -sf "$(CURDIR)/scripts/pre-commit.hook" "$(CURDIR)/.git/hooks/pre-commit"
 
@@ -79,7 +85,7 @@ coverhtml: vet common
 	GOPATH=$(GOPATH) $(GO) tool cover -html=cover.out -o coverage.html
 
 %_easyjson.go: %.go ./vendor/bin/easyjson
-	PATH=$(shell dirname $(GO)):$(PATH) GOPATH=$(GOPATH) ./vendor/bin/easyjson -all $*.go
+	PATH=$(shell dirname $(GO)):$(PATH) GOPATH=$(GOPATH) "$(VENDORBIN)/easyjson" -all $*.go
 
 common: \
 	api_signaling_easyjson.go \


### PR DESCRIPTION
Otherwise it fails like

```
GOPATH="/go/src/github.com/strukturag/nextcloud-spreed-signaling/vendor:/go/src/github.com/strukturag/nextcloud-spreed-signaling" /usr/local/go/bin/go get -u github.com/mailru/easyjson/...
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading github.com/josharian/intern v1.0.0
PATH=/usr/local/go/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin GOPATH="/go/src/github.com/strukturag/nextcloud-spreed-signaling/vendor:/go/src/github.com/strukturag/nextcloud-spreed-signaling" ./vendor/bin/easyjson -all api_signaling.go
/bin/sh: 1: ./vendor/bin/easyjson: not found
```