### PR TITLE
Force HTTPS for backend connections in old-style configurations.

### DIFF
--- a/backend_client_test.go
+++ b/backend_client_test.go
@@ -87,6 +87,9 @@ func TestPostOnRedirect(t *testing.T) {
 	config := goconf.NewConfigFile()
 	config.AddOption("backend", "allowed", u.Host)
 	config.AddOption("backend", "secret", string(testBackendSecret))
+	if u.Scheme == "http" {
+		config.AddOption("backend", "allowhttp", "true")
+	}
 	client, err := NewBackendClient(config, 1, "0.0")
 	if err != nil {
 		t.Fatal(err)

--- a/backend_server_test.go
+++ b/backend_server_test.go
@@ -77,6 +77,9 @@ func CreateBackendServerForTestFromConfig(t *testing.T, config *goconf.ConfigFil
 		t.Fatal(err)
 	}
 	config.AddOption("backend", "allowed", u.Host)
+	if u.Scheme == "http" {
+		config.AddOption("backend", "allowhttp", "true")
+	}
 	config.AddOption("backend", "secret", string(testBackendSecret))
 	config.AddOption("sessions", "hashkey", "12345678901234567890123456789012")
 	config.AddOption("sessions", "blockkey", "09876543210987654321098765432109")

--- a/hub_test.go
+++ b/hub_test.go
@@ -68,6 +68,9 @@ func getTestConfig(server *httptest.Server) (*goconf.ConfigFile, error) {
 		return nil, err
 	}
 	config.AddOption("backend", "allowed", u.Host)
+	if u.Scheme == "http" {
+		config.AddOption("backend", "allowhttp", "true")
+	}
 	config.AddOption("backend", "secret", string(testBackendSecret))
 	config.AddOption("sessions", "hashkey", "12345678901234567890123456789012")
 	config.AddOption("sessions", "blockkey", "09876543210987654321098765432109")


### PR DESCRIPTION
Prevents clients from sending a HTTP auth URL to trigger an insecure connection from the signaling server to Nextcloud.

@LukasReschke FYI

Fixes #130