### PR TITLE
Support continent mapping overrides.

### DIFF
--- a/geoip.go
+++ b/geoip.go
@@ -239,3 +239,31 @@ func LookupContinents(country string) []string {
 		return continents
 	}
 }
+
+func IsValidContinent(continent string) bool {
+	switch continent {
+	case "AF":
+		// Africa
+		fallthrough
+	case "AN":
+		// Antartica
+		fallthrough
+	case "AS":
+		// Asia
+		fallthrough
+	case "EU":
+		// Europe
+		fallthrough
+	case "NA":
+		// North America
+		fallthrough
+	case "SA":
+		// South America
+		fallthrough
+	case "OC":
+		// Oceania
+		return true
+	default:
+		return false
+	}
+}

--- a/geoip_test.go
+++ b/geoip_test.go
@@ -200,3 +200,13 @@ func TestGeoLookupFromFile(t *testing.T) {
 
 	testGeoLookupReader(t, reader)
 }
+
+func TestIsValidContinent(t *testing.T) {
+	for country, continents := range ContinentMap {
+		for _, continent := range continents {
+			if !IsValidContinent(continent) {
+				t.Errorf("Continent %s of country %s is not valid", continent, country)
+			}
+		}
+	}
+}

--- a/server.conf.in
+++ b/server.conf.in
@@ -210,6 +210,14 @@ connectionsperhost = 8
 #127.0.0.1 = DE
 #192.168.0.0/24 = DE
 
+[continent-overrides]
+# Optional overrides for continent mappings. The key is a continent code, the
+# value a comma-separated list of continent codes to map the continent to.
+# Use European servers for clients in Africa.
+#AF = EU
+# Use servers in North Africa for clients in South America.
+#SA = NA
+
 [stats]
 # Comma-separated list of IP addresses that are allowed to access the stats
 # endpoint. Leave empty (or commented) to only allow access from "127.0.0.1".


### PR DESCRIPTION
This can be used for example to route all users on continent A to proxies on continent B. Useful if no proxy exists on continent A and the global selection chooses a non-ideal proxy.