### PR TITLE
Include room session id in "joined" events.

### DIFF
--- a/api_signaling.go
+++ b/api_signaling.go
@@ -632,9 +632,10 @@ type EventServerMessage struct {
 }
 
 type EventServerMessageSessionEntry struct {
-	SessionId string           `json:"sessionid"`
-	UserId    string           `json:"userid"`
-	User      *json.RawMessage `json:"user,omitempty"`
+	SessionId     string           `json:"sessionid"`
+	UserId        string           `json:"userid"`
+	User          *json.RawMessage `json:"user,omitempty"`
+	RoomSessionId string           `json:"roomsessionid,omitempty"`
 }
 
 // MCU-related types

--- a/hub.go
+++ b/hub.go
@@ -1186,11 +1186,15 @@ func (h *Hub) notifyUserJoinedRoom(room *Room, session *ClientSession, sessionDa
 	if sessions := room.AddSession(session, sessionData); len(sessions) > 0 {
 		events := make([]*EventServerMessageSessionEntry, 0, len(sessions))
 		for _, s := range sessions {
-			events = append(events, &EventServerMessageSessionEntry{
+			entry := &EventServerMessageSessionEntry{
 				SessionId: s.PublicId(),
 				UserId:    s.UserId(),
 				User:      s.UserData(),
-			})
+			}
+			if s, ok := s.(*ClientSession); ok {
+				entry.RoomSessionId = s.RoomSessionId()
+			}
+			events = append(events, entry)
 		}
 		msg := &ServerMessage{
 			Type: "event",

--- a/room.go
+++ b/room.go
@@ -439,6 +439,9 @@ func (r *Room) PublishSessionJoined(session Session, sessionData *RoomSessionDat
 			},
 		},
 	}
+	if session, ok := session.(*ClientSession); ok {
+		message.Event.Join[0].RoomSessionId = session.RoomSessionId()
+	}
 	if err := r.publish(message); err != nil {
 		log.Printf("Could not publish session joined message in room %s: %s", r.Id(), err)
 	}

--- a/room_test.go
+++ b/room_test.go
@@ -397,6 +397,8 @@ func TestRoom_RoomSessionData(t *testing.T) {
 		t.Error(err)
 	} else if err := client.checkMessageJoinedSession(message, hello.Hello.SessionId, expected); err != nil {
 		t.Error(err)
+	} else if message.Event.Join[0].RoomSessionId != roomId+"-"+hello.Hello.SessionId {
+		t.Errorf("Expected join room session id %s, got %+v", roomId+"-"+hello.Hello.SessionId, message.Event.Join[0])
 	}
 
 	session := hub.GetSessionByPublicId(hello.Hello.SessionId)


### PR DESCRIPTION
This helps with matching signaling sessions with sessions in Talk.