### PR TITLE
Clients can provide the maximum publishing bandwidth in offer requests.

### DIFF
--- a/api_signaling.go
+++ b/api_signaling.go
@@ -411,6 +411,7 @@ type MessageClientMessageData struct {
 	Type     string                 `json:"type"`
 	Sid      string                 `json:"sid"`
 	RoomType string                 `json:"roomType"`
+	Bitrate  int                    `json:"bitrate,omitempty"`
 	Payload  map[string]interface{} `json:"payload"`
 }
 

--- a/clientsession.go
+++ b/clientsession.go
@@ -820,12 +820,18 @@ func (s *ClientSession) GetOrCreatePublisher(ctx context.Context, mcu Mcu, strea
 		client := s.getClientUnlocked()
 		s.mu.Unlock()
 
-		var bitrate int
+		bitrate := data.Bitrate
 		if backend := s.Backend(); backend != nil {
+			var maxBitrate int
 			if streamType == streamTypeScreen {
-				bitrate = backend.maxScreenBitrate
+				maxBitrate = backend.maxScreenBitrate
 			} else {
-				bitrate = backend.maxStreamBitrate
+				maxBitrate = backend.maxStreamBitrate
+			}
+			if bitrate <= 0 {
+				bitrate = maxBitrate
+			} else if maxBitrate > 0 && bitrate > maxBitrate {
+				bitrate = maxBitrate
 			}
 		}
 		var err error

--- a/mcu_test.go
+++ b/mcu_test.go
@@ -31,6 +31,11 @@ import (
 	"github.com/dlintw/goconf"
 )
 
+const (
+	TestMaxBitrateScreen = 12345678
+	TestMaxBitrateVideo  = 23456789
+)
+
 type TestMCU struct {
 	mu         sync.Mutex
 	publishers map[string]*TestMCUPublisher
@@ -63,6 +68,17 @@ func (m *TestMCU) GetStats() interface{} {
 }
 
 func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, bitrate int, mediaTypes MediaType, initiator McuInitiator) (McuPublisher, error) {
+	var maxBitrate int
+	if streamType == streamTypeScreen {
+		maxBitrate = TestMaxBitrateScreen
+	} else {
+		maxBitrate = TestMaxBitrateVideo
+	}
+	if bitrate <= 0 {
+		bitrate = maxBitrate
+	} else if bitrate > maxBitrate {
+		bitrate = maxBitrate
+	}
 	pub := &TestMCUPublisher{
 		TestMCUClient: TestMCUClient{
 			id:         id,
@@ -70,6 +86,7 @@ func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id str
 		},
 
 		mediaTypes: mediaTypes,
+		bitrate:    bitrate,
 	}
 
 	m.mu.Lock()
@@ -129,6 +146,7 @@ type TestMCUPublisher struct {
 	TestMCUClient
 
 	mediaTypes MediaType
+	bitrate    int
 }
 
 func (p *TestMCUPublisher) HasMedia(mt MediaType) bool {


### PR DESCRIPTION
This will still be capped to any backend / proxy / Janus limits.