### PR TITLE
Add API for transient room data.

### DIFF
--- a/docs/standalone-signaling-api-v1.md
+++ b/docs/standalone-signaling-api-v1.md
@@ -657,6 +657,104 @@ Message format (Server -> Client, receive message)
 - The `userid` is omitted if a message was sent by an anonymous user.
 
 
+## Transient data
+
+Transient data can be used to share data in a room that is valid while sessions
+are still connected to the room. This can be used for example to have a shared
+state in a meeting without having each client to request data from the Nextcloud
+server. The data is automatically cleared when the last session disconnects.
+
+Sessions must be in a room and need the permission flag `transient-data` in
+order to set or remove values. All sessions in a room automatically receive
+all transient data update events.
+
+Transient data is supported if the server returns the `transient-data` feature
+id in the [hello response](#establish-connection).
+
+
+### Set value
+
+Message format (Client -> Server):
+
+    {
+      "type": "transient",
+      "transient": {
+        "type": "set",
+        "key": "sample-key",
+        "value": "any-json-object"
+      }
+    }
+
+- The `key` must be a string.
+- The `value` can be of any type (i.e. string, number, array, object, etc.).
+- Requests to set a value that is already present for the key are silently
+  ignored.
+
+
+Message format (Server -> Client):
+
+    {
+      "type": "transient",
+      "transient": {
+        "type": "set",
+        "key": "sample-key",
+        "value": "any-json-object",
+        "oldvalue": "the-previous-value-if-any"
+      }
+    }
+
+- The `oldvalue` is only present if a previous value was stored for the key.
+
+
+### Remove value
+
+Message format (Client -> Server):
+
+    {
+      "type": "transient",
+      "transient": {
+        "type": "remove",
+        "key": "sample-key"
+      }
+    }
+
+- The `key` must be a string.
+- Requests to remove a key that doesn't exist are silently ignored.
+
+
+Message format (Server -> Client):
+
+    {
+      "type": "transient",
+      "transient": {
+        "type": "remove",
+        "key": "sample-key",
+        "oldvalue": "the-previous-value-if-any"
+      }
+    }
+
+- The `oldvalue` is only present if a previous value was stored for the key.
+
+
+### Initial data
+
+When sessions initially join a room, they receive the current state of the
+transient data.
+
+Message format (Server -> Client):
+
+    {
+      "type": "transient",
+      "transient": {
+        "type": "initial",
+        "data": {
+          "sample-key": "sample-value",
+          ...
+        }
+      }
+    }
+
+
 # Internal signaling server API
 
 The signaling server provides an internal API that can be called from Nextcloud

--- a/session.go
+++ b/session.go
@@ -35,6 +35,7 @@ var (
 	PERMISSION_MAY_PUBLISH_VIDEO  Permission = "publish-video"
 	PERMISSION_MAY_PUBLISH_SCREEN Permission = "publish-screen"
 	PERMISSION_MAY_CONTROL        Permission = "control"
+	PERMISSION_TRANSIENT_DATA     Permission = "transient-data"
 )
 
 type SessionIdData struct {

--- a/transient_data.go
+++ b/transient_data.go
@@ -1,0 +1,189 @@
+/**
+ * Standalone signaling server for the Nextcloud Spreed app.
+ * Copyright (C) 2021 struktur AG
+ *
+ * @author Joachim Bauch <bauch@struktur.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package signaling
+
+import (
+	"reflect"
+	"sync"
+)
+
+type TransientListener interface {
+	SendMessage(message *ServerMessage) bool
+}
+
+type TransientData struct {
+	mu        sync.Mutex
+	data      map[string]interface{}
+	listeners map[TransientListener]bool
+}
+
+// NewTransientData creates a new transient data container.
+func NewTransientData() *TransientData {
+	return &TransientData{}
+}
+
+func (t *TransientData) notifySet(key string, prev, value interface{}) {
+	msg := &ServerMessage{
+		Type: "transient",
+		TransientData: &TransientDataServerMessage{
+			Type:     "set",
+			Key:      key,
+			OldValue: prev,
+			Value:    value,
+		},
+	}
+	for listener := range t.listeners {
+		listener.SendMessage(msg)
+	}
+}
+
+func (t *TransientData) notifyDeleted(key string, prev interface{}) {
+	msg := &ServerMessage{
+		Type: "transient",
+		TransientData: &TransientDataServerMessage{
+			Type:     "remove",
+			Key:      key,
+			OldValue: prev,
+		},
+	}
+	for listener := range t.listeners {
+		listener.SendMessage(msg)
+	}
+}
+
+// AddListener adds a new listener to be notified about changes.
+func (t *TransientData) AddListener(listener TransientListener) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.listeners == nil {
+		t.listeners = make(map[TransientListener]bool)
+	}
+	t.listeners[listener] = true
+	if len(t.data) > 0 {
+		msg := &ServerMessage{
+			Type: "transient",
+			TransientData: &TransientDataServerMessage{
+				Type: "initial",
+				Data: t.data,
+			},
+		}
+		listener.SendMessage(msg)
+	}
+}
+
+// RemoveListener removes a previously registered listener.
+func (t *TransientData) RemoveListener(listener TransientListener) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	delete(t.listeners, listener)
+}
+
+// Set sets a new value for the given key and notifies listeners
+// if the value has been changed.
+func (t *TransientData) Set(key string, value interface{}) bool {
+	if value == nil {
+		return t.Remove(key)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prev, found := t.data[key]
+	if found && reflect.DeepEqual(prev, value) {
+		return false
+	}
+
+	if t.data == nil {
+		t.data = make(map[string]interface{})
+	}
+	t.data[key] = value
+	t.notifySet(key, prev, value)
+	return true
+}
+
+// CompareAndSet sets a new value for the given key only for a given old value
+// and notifies listeners if the value has been changed.
+func (t *TransientData) CompareAndSet(key string, old, value interface{}) bool {
+	if value == nil {
+		return t.CompareAndRemove(key, old)
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prev, found := t.data[key]
+	if old != nil && (!found || !reflect.DeepEqual(prev, old)) {
+		return false
+	} else if old == nil && found {
+		return false
+	}
+
+	t.data[key] = value
+	t.notifySet(key, prev, value)
+	return true
+}
+
+// Remove deletes the value with the given key and notifies listeners
+// if the key was removed.
+func (t *TransientData) Remove(key string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prev, found := t.data[key]
+	if !found {
+		return false
+	}
+
+	delete(t.data, key)
+	t.notifyDeleted(key, prev)
+	return true
+}
+
+// CompareAndRemove deletes the value with the given key if it has a given value
+// and notifies listeners if the key was removed.
+func (t *TransientData) CompareAndRemove(key string, old interface{}) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	prev, found := t.data[key]
+	if !found || !reflect.DeepEqual(prev, old) {
+		return false
+	}
+
+	delete(t.data, key)
+	t.notifyDeleted(key, prev)
+	return true
+}
+
+// GetData returns a copy of the internal data.
+func (t *TransientData) GetData() map[string]interface{} {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	result := make(map[string]interface{})
+	for k, v := range t.data {
+		result[k] = v
+	}
+	return result
+}

--- a/transient_data_test.go
+++ b/transient_data_test.go
@@ -1,0 +1,294 @@
+/**
+ * Standalone signaling server for the Nextcloud Spreed app.
+ * Copyright (C) 2021 struktur AG
+ *
+ * @author Joachim Bauch <bauch@struktur.de>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package signaling
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func Test_TransientData(t *testing.T) {
+	data := NewTransientData()
+	if data.Set("foo", nil) {
+		t.Errorf("should not have set value")
+	}
+	if !data.Set("foo", "bar") {
+		t.Errorf("should have set value")
+	}
+	if data.Set("foo", "bar") {
+		t.Errorf("should not have set value")
+	}
+	if !data.Set("foo", "baz") {
+		t.Errorf("should have set value")
+	}
+	if data.CompareAndSet("foo", "bar", "lala") {
+		t.Errorf("should not have set value")
+	}
+	if !data.CompareAndSet("foo", "baz", "lala") {
+		t.Errorf("should have set value")
+	}
+	if data.CompareAndSet("test", nil, nil) {
+		t.Errorf("should not have set value")
+	}
+	if !data.CompareAndSet("test", nil, "123") {
+		t.Errorf("should have set value")
+	}
+	if data.CompareAndRemove("test", "1234") {
+		t.Errorf("should not have removed value")
+	}
+	if !data.CompareAndRemove("test", "123") {
+		t.Errorf("should have removed value")
+	}
+	if data.Remove("lala") {
+		t.Errorf("should not have removed value")
+	}
+	if !data.Remove("foo") {
+		t.Errorf("should have removed value")
+	}
+}
+
+func Test_TransientMessages(t *testing.T) {
+	hub, _, _, server, shutdown := CreateHubForTest(t)
+	defer shutdown()
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client1 := NewTestClient(t, server, hub)
+	defer client1.CloseWithBye()
+	if err := client1.SendHello(testDefaultUserId + "1"); err != nil {
+		t.Fatal(err)
+	}
+	hello1, err := client1.RunUntilHello(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := client1.SetTransientData("foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	if msg, err := client1.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageError(msg, "not_in_room"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	client2 := NewTestClient(t, server, hub)
+	defer client2.CloseWithBye()
+	if err := client2.SendHello(testDefaultUserId + "2"); err != nil {
+		t.Fatal(err)
+	}
+	hello2, err := client2.RunUntilHello(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Join room by id.
+	roomId := "test-room"
+	if room, err := client1.JoinRoom(ctx, roomId); err != nil {
+		t.Fatal(err)
+	} else if room.Room.RoomId != roomId {
+		t.Fatalf("Expected room %s, got %s", roomId, room.Room.RoomId)
+	}
+
+	// Give message processing some time.
+	time.Sleep(10 * time.Millisecond)
+
+	if room, err := client2.JoinRoom(ctx, roomId); err != nil {
+		t.Fatal(err)
+	} else if room.Room.RoomId != roomId {
+		t.Fatalf("Expected room %s, got %s", roomId, room.Room.RoomId)
+	}
+
+	WaitForUsersJoined(ctx, t, client1, hello1, client2, hello2)
+
+	session1 := hub.GetSessionByPublicId(hello1.Hello.SessionId).(*ClientSession)
+	if session1 == nil {
+		t.Fatalf("Session %s does not exist", hello1.Hello.SessionId)
+	}
+	session2 := hub.GetSessionByPublicId(hello2.Hello.SessionId).(*ClientSession)
+	if session2 == nil {
+		t.Fatalf("Session %s does not exist", hello2.Hello.SessionId)
+	}
+
+	// Client 1 may modify transient data.
+	session1.SetPermissions([]Permission{PERMISSION_TRANSIENT_DATA})
+	// Client 2 may not modify transient data.
+	session2.SetPermissions([]Permission{})
+
+	if err := client2.SetTransientData("foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	if msg, err := client2.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageError(msg, "not_allowed"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := client1.SetTransientData("foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg, err := client1.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageTransientSet(msg, "foo", "bar", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if msg, err := client2.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageTransientSet(msg, "foo", "bar", nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := client2.RemoveTransientData("foo"); err != nil {
+		t.Fatal(err)
+	}
+	if msg, err := client2.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageError(msg, "not_allowed"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Setting the same value is ignored by the server.
+	if err := client1.SetTransientData("foo", "bar"); err != nil {
+		t.Fatal(err)
+	}
+	ctx2, cancel2 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel2()
+
+	if msg, err := client1.RunUntilMessage(ctx2); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatal(err)
+		}
+	} else {
+		t.Errorf("Expected no payload, got %+v", msg)
+	}
+
+	data := map[string]interface{}{
+		"hello": "world",
+	}
+	if err := client1.SetTransientData("foo", data); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg, err := client1.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageTransientSet(msg, "foo", data, "bar"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if msg, err := client2.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageTransientSet(msg, "foo", data, "bar"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := client1.RemoveTransientData("foo"); err != nil {
+		t.Fatal(err)
+	}
+
+	if msg, err := client1.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageTransientRemove(msg, "foo", data); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if msg, err := client2.RunUntilMessage(ctx); err != nil {
+		t.Fatal(err)
+	} else {
+		if err := checkMessageTransientRemove(msg, "foo", data); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Removing a non-existing key is ignored by the server.
+	if err := client1.RemoveTransientData("foo"); err != nil {
+		t.Fatal(err)
+	}
+	ctx3, cancel3 := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel3()
+
+	if msg, err := client1.RunUntilMessage(ctx3); err != nil {
+		if err != context.DeadlineExceeded {
+			t.Fatal(err)
+		}
+	} else {
+		t.Errorf("Expected no payload, got %+v", msg)
+	}
+
+	if err := client1.SetTransientData("abc", data); err != nil {
+		t.Fatal(err)
+	}
+
+	client3 := NewTestClient(t, server, hub)
+	defer client3.CloseWithBye()
+	if err := client3.SendHello(testDefaultUserId + "3"); err != nil {
+		t.Fatal(err)
+	}
+	hello3, err := client3.RunUntilHello(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if room, err := client3.JoinRoom(ctx, roomId); err != nil {
+		t.Fatal(err)
+	} else if room.Room.RoomId != roomId {
+		t.Fatalf("Expected room %s, got %s", roomId, room.Room.RoomId)
+	}
+
+	ignored, err := client3.RunUntilJoinedAndReturnIgnored(ctx, hello1.Hello, hello2.Hello, hello3.Hello)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var msg *ServerMessage
+	if len(ignored) == 0 {
+		if msg, err = client3.RunUntilMessage(ctx); err != nil {
+			t.Fatal(err)
+		}
+	} else if len(ignored) == 1 {
+		msg = ignored[0]
+	} else {
+		t.Fatalf("Received too many messages: %+v", ignored)
+	}
+
+	if err := checkMessageTransientInitial(msg, map[string]interface{}{
+		"abc": data,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Transient room data only exists while sessions are connected to a room, i.e. it is not stored persistently in a database. Changes are broadcast to all sessions in the room and the initial state is sent to new sessions on join.
A new feature flag was added so clients can check if transient data is available and sessions need a new permission to be able to set / change / remove transient data fields.

This could be used to store data that is valid while a meeting is taking place but can be cleared when nobody is connected.