### PR TITLE
Send updated offers to subscribers after publisher renegotiations

### DIFF
--- a/api_signaling.go
+++ b/api_signaling.go
@@ -647,4 +647,5 @@ type AnswerOfferMessage struct {
 	Type     string                 `json:"type"`
 	RoomType string                 `json:"roomType"`
 	Payload  map[string]interface{} `json:"payload"`
+	Update   bool                   `json:"update,omitempty"`
 }

--- a/api_signaling.go
+++ b/api_signaling.go
@@ -325,6 +325,7 @@ const (
 	// Features for all clients.
 	ServerFeatureMcu                   = "mcu"
 	ServerFeatureSimulcast             = "simulcast"
+	ServerFeatureUpdateSdp             = "update-sdp"
 	ServerFeatureAudioVideoPermissions = "audio-video-permissions"
 
 	// Features for internal clients only.

--- a/clientsession.go
+++ b/clientsession.go
@@ -563,6 +563,34 @@ func (s *ClientSession) SetClient(client *Client) *Client {
 	return prev
 }
 
+func (s *ClientSession) sendOffer(client McuClient, sender string, streamType string, offer map[string]interface{}) {
+	offer_message := &AnswerOfferMessage{
+		To:       s.PublicId(),
+		From:     sender,
+		Type:     "offer",
+		RoomType: streamType,
+		Payload:  offer,
+		Update:   true,
+	}
+	offer_data, err := json.Marshal(offer_message)
+	if err != nil {
+		log.Println("Could not serialize offer", offer_message, err)
+		return
+	}
+	response_message := &ServerMessage{
+		Type: "message",
+		Message: &MessageServerMessage{
+			Sender: &MessageServerMessageSender{
+				Type:      "session",
+				SessionId: sender,
+			},
+			Data: (*json.RawMessage)(&offer_data),
+		},
+	}
+
+	s.sendMessageUnlocked(response_message)
+}
+
 func (s *ClientSession) sendCandidate(client McuClient, sender string, streamType string, candidate interface{}) {
 	candidate_message := &AnswerOfferMessage{
 		To:       s.PublicId(),
@@ -626,6 +654,18 @@ func (s *ClientSession) SendMessages(messages []*ServerMessage) bool {
 		s.sendMessageUnlocked(message)
 	}
 	return true
+}
+
+func (s *ClientSession) OnUpdateOffer(client McuClient, offer map[string]interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, sub := range s.subscribers {
+		if sub.Id() == client.Id() {
+			s.sendOffer(client, sub.Publisher(), client.StreamType(), offer)
+			return
+		}
+	}
 }
 
 func (s *ClientSession) OnIceCandidate(client McuClient, candidate interface{}) {

--- a/hub.go
+++ b/hub.go
@@ -371,14 +371,18 @@ func (h *Hub) SetMcu(mcu Mcu) {
 	if mcu == nil {
 		removeFeature(h.info, ServerFeatureMcu)
 		removeFeature(h.info, ServerFeatureSimulcast)
+		removeFeature(h.info, ServerFeatureUpdateSdp)
 		removeFeature(h.infoInternal, ServerFeatureMcu)
 		removeFeature(h.infoInternal, ServerFeatureSimulcast)
+		removeFeature(h.infoInternal, ServerFeatureUpdateSdp)
 	} else {
 		log.Printf("Using a timeout of %s for MCU requests", h.mcuTimeout)
 		addFeature(h.info, ServerFeatureMcu)
 		addFeature(h.info, ServerFeatureSimulcast)
+		addFeature(h.info, ServerFeatureUpdateSdp)
 		addFeature(h.infoInternal, ServerFeatureMcu)
 		addFeature(h.infoInternal, ServerFeatureSimulcast)
+		addFeature(h.infoInternal, ServerFeatureUpdateSdp)
 	}
 }
 

--- a/mcu_common.go
+++ b/mcu_common.go
@@ -50,6 +50,8 @@ const (
 type McuListener interface {
 	PublicId() string
 
+	OnUpdateOffer(client McuClient, offer map[string]interface{})
+
 	OnIceCandidate(client McuClient, candidate interface{})
 	OnIceCompleted(client McuClient)
 

--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -1063,7 +1063,12 @@ func (p *mcuJanusSubscriber) handleEvent(event *janus.EventMsg) {
 			log.Printf("Subscriber %d: associated room has been destroyed, closing", p.handleId)
 			go p.Close(ctx)
 		case "event":
-			// Ignore events like selected substream / temporal layer.
+			// Handle renegotiations, but ignore other events like selected
+			// substream / temporal layer.
+			if getPluginStringValue(event.Plugindata, pluginVideoRoom, "configured") == "ok" &&
+				event.Jsep != nil && event.Jsep["type"] == "offer" && event.Jsep["sdp"] != nil {
+				p.listener.OnUpdateOffer(p, event.Jsep)
+			}
 		case "slow_link":
 			// Ignore, processed through "handleSlowLink" in the general events.
 		default:

--- a/mcu_proxy.go
+++ b/mcu_proxy.go
@@ -107,6 +107,8 @@ func (c *mcuProxyPubSubCommon) doSendMessage(ctx context.Context, msg *ProxyClie
 
 func (c *mcuProxyPubSubCommon) doProcessPayload(client McuClient, msg *PayloadProxyServerMessage) {
 	switch msg.Type {
+	case "offer":
+		c.listener.OnUpdateOffer(client, msg.Payload["offer"].(map[string]interface{}))
 	case "candidate":
 		c.listener.OnIceCandidate(client, msg.Payload["candidate"])
 	default:

--- a/proxy/proxy_session.go
+++ b/proxy/proxy_session.go
@@ -122,6 +122,26 @@ func (s *ProxySession) SetClient(client *ProxyClient) *ProxyClient {
 	return prev
 }
 
+func (s *ProxySession) OnUpdateOffer(client signaling.McuClient, offer map[string]interface{}) {
+	id := s.proxy.GetClientId(client)
+	if id == "" {
+		log.Printf("Received offer %+v from unknown %s client %s (%+v)", offer, client.StreamType(), client.Id(), client)
+		return
+	}
+
+	msg := &signaling.ProxyServerMessage{
+		Type: "payload",
+		Payload: &signaling.PayloadProxyServerMessage{
+			Type:     "offer",
+			ClientId: id,
+			Payload:  map[string]interface{}{
+				"offer": offer,
+			},
+		},
+	}
+	s.sendMessage(msg)
+}
+
 func (s *ProxySession) OnIceCandidate(client signaling.McuClient, candidate interface{}) {
 	id := s.proxy.GetClientId(client)
 	if id == "" {


### PR DESCRIPTION
Although related, this is independent from #191.

Tested also when running against a proxy :-)

When a publisher has a connection the publisher can update the connection (for example, to add a video track to an audio only connection) by sending an updated offer to Janus. Janus detects that, adjusts the connection and then sends back an answer. Once the publisher connection is updated Janus starts a renegotiation for the subscribers and generates the offers to be sent to them.

The signaling server did not handle the event, so the offers were not sent and the subscriber connections were not updated. Now the offers are sent as needed, which makes possible for the renegotiation to be completed by the clients.

In this case the `offer` message will also include an `update` parameter so clients can differentiate between offers to create new connections or update the existing one.

A new feature flag, `publisher-update`, is also introduced to notify clients whether updating publisher connections is supported or not (supported as in _it will cause renegotiation offers to be sent for the subscribers_). This is needed for the clients to differentiate if they can just send an updated offer or if they need to force a reconnection. However, would it be better to drop the flag here and add a single flag about renegotiations once #191 is ready?

Some things I am not very sure about (I am quite unsure about any change made by me to this code, but specially about these :-P ):
- `OnOffer` should be called `OnUpdatedSubscriberOffer`, `OnConfiguredSubscriber` or something like that? `OnOffer` may be a bit misleading, as it looks like it would be called for any offer, and not only when a negotiation is needed in Janus for a subscriber and thus the offer needs to be sent to the other peer.
- Second parameter of `OnOffer` is defined as `map[string]interface{}`, as it carries the offer provided by Janus in `event.Jsep` (_mcu_janus.go_), which (currently) is a string indexed map with fields `sdp` and `type`. However, in _mcu_proxy.go_ `msg.Payload["offer"]` is `interface{}`, so the compiler complains that it needs to be type asserted to `map[string]interface{}`. Is there a better way to do it? Note that if the second parameter of `OnOffer` is changed to `interface{}` then the type assertion will be needed in _clientsession.go_ in `Payload:offer`.
- Could there be any possible race condition if a new subscriber joins when the publisher is updated?
