### PR TITLE
Fix mediaType not updated after publisher renegotiations

### DIFF
--- a/clientsession.go
+++ b/clientsession.go
@@ -895,6 +895,8 @@ func (s *ClientSession) GetOrCreatePublisher(ctx context.Context, mcu Mcu, strea
 			s.publishers[streamType] = publisher
 		}
 		log.Printf("Publishing %s as %s for session %s", streamType, publisher.Id(), s.PublicId())
+	} else {
+		publisher.SetMedia(mediaTypes)
 	}
 
 	return publisher, nil

--- a/mcu_common.go
+++ b/mcu_common.go
@@ -90,6 +90,7 @@ type McuPublisher interface {
 	McuClient
 
 	HasMedia(MediaType) bool
+	SetMedia(MediaType)
 }
 
 type McuSubscriber interface {

--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -883,6 +883,10 @@ func (p *mcuJanusPublisher) HasMedia(mt MediaType) bool {
 	return (p.mediaTypes & mt) == mt
 }
 
+func (p *mcuJanusPublisher) SetMedia(mt MediaType) {
+	p.mediaTypes = mt
+}
+
 func (p *mcuJanusPublisher) NotifyReconnected() {
 	ctx := context.TODO()
 	handle, session, roomId, err := p.mcu.getOrCreatePublisherHandle(ctx, p.id, p.streamType, p.bitrate)

--- a/mcu_proxy.go
+++ b/mcu_proxy.go
@@ -144,6 +144,11 @@ func (p *mcuProxyPublisher) HasMedia(mt MediaType) bool {
 	return (p.mediaTypes & mt) == mt
 }
 
+func (p *mcuProxyPublisher) SetMedia(mt MediaType) {
+	// TODO: Also update mediaTypes on proxy.
+	p.mediaTypes = mt
+}
+
 func (p *mcuProxyPublisher) NotifyClosed() {
 	p.listener.PublisherClosed(p)
 	p.conn.removePublisher(p)

--- a/mcu_test.go
+++ b/mcu_test.go
@@ -153,6 +153,10 @@ func (p *TestMCUPublisher) HasMedia(mt MediaType) bool {
 	return (p.mediaTypes & mt) == mt
 }
 
+func (p *TestMCUPublisher) SetMedia(mt MediaType) {
+	p.mediaTypes = mt
+}
+
 func (p *TestMCUPublisher) SendMessage(ctx context.Context, message *MessageClientMessage, data *MessageClientMessageData, callback func(error, map[string]interface{})) {
 	go func() {
 		if p.isClosed() {


### PR DESCRIPTION
Follow up to #195

[When the permissions are updated and the session is no longer allowed to publish audio or video the publisher is closed](https://github.com/strukturag/nextcloud-spreed-signaling/blob/8fd9c688b6bdfe6f92259b07e1c4004fd432c637/clientsession.go#L970). The check is based on the [`mediaTypes` of the publisher](https://github.com/strukturag/nextcloud-spreed-signaling/blob/8fd9c688b6bdfe6f92259b07e1c4004fd432c637/mcu_janus.go#L883), which [are set when the publisher is initially created](https://github.com/strukturag/nextcloud-spreed-signaling/blob/8fd9c688b6bdfe6f92259b07e1c4004fd432c637/clientsession.go#L879) based on [the received offer](https://github.com/strukturag/nextcloud-spreed-signaling/blob/8fd9c688b6bdfe6f92259b07e1c4004fd432c637/clientsession.go#L854).

However, since #195 an updated offer can be received for an already existing publisher. In that case the `mediaTypes` need to be updated, as otherwise the publisher could add media not included in the original offer and the signaling server would not close the connection if the permission for that media is then revoked.

## How to test

- Use https://github.com/nextcloud/spreed/pull/6896, but prevent renegotiations when a track is removed by commenting https://github.com/nextcloud/spreed/blob/e31893f9fab75cce95e6166a14baf6e1a7c36fb8/src/utils/webrtc/webrtc.js#L1066
- Disable video permissions by default
- Start a call
- In a private window, join the conversation as a guest or regular user
- Join the call with audio and video (although video will be blocked)
- In the original window, allow video for the other participant
- Disallow video again for the other participant

### Result with this pull request

The publisher connection is closed

### Result without this pull request

The publisher connection is not closed
