### PR TITLE
Add specific id for connections and replace "update" parameter with it

### DIFF
--- a/api_proxy.go
+++ b/api_proxy.go
@@ -172,6 +172,7 @@ type ByeProxyServerMessage struct {
 type CommandProxyClientMessage struct {
 	Type string `json:"type"`
 
+	Sid         string    `json:"sid,omitempty"`
 	StreamType  string    `json:"streamType,omitempty"`
 	PublisherId string    `json:"publisherId,omitempty"`
 	ClientId    string    `json:"clientId,omitempty"`
@@ -205,7 +206,8 @@ func (m *CommandProxyClientMessage) CheckValid() error {
 }
 
 type CommandProxyServerMessage struct {
-	Id string `json:"id,omitempty"`
+	Id  string `json:"id,omitempty"`
+	Sid string `json:"sid,omitempty"`
 }
 
 // Type "payload"
@@ -254,6 +256,7 @@ type EventProxyServerMessage struct {
 
 	ClientId string `json:"clientId,omitempty"`
 	Load     int64  `json:"load,omitempty"`
+	Sid      string `json:"sid,omitempty"`
 }
 
 // Information on a proxy in the etcd cluster.

--- a/api_proxy.go
+++ b/api_proxy.go
@@ -216,6 +216,7 @@ type PayloadProxyClientMessage struct {
 	Type string `json:"type"`
 
 	ClientId string                 `json:"clientId"`
+	Sid      string                 `json:"sid,omitempty"`
 	Payload  map[string]interface{} `json:"payload,omitempty"`
 }
 

--- a/api_signaling.go
+++ b/api_signaling.go
@@ -655,7 +655,6 @@ type AnswerOfferMessage struct {
 	RoomType string                 `json:"roomType"`
 	Payload  map[string]interface{} `json:"payload"`
 	Sid      string                 `json:"sid,omitempty"`
-	Update   bool                   `json:"update,omitempty"`
 }
 
 // Type "transient"

--- a/api_signaling.go
+++ b/api_signaling.go
@@ -654,6 +654,7 @@ type AnswerOfferMessage struct {
 	Type     string                 `json:"type"`
 	RoomType string                 `json:"roomType"`
 	Payload  map[string]interface{} `json:"payload"`
+	Sid      string                 `json:"sid,omitempty"`
 	Update   bool                   `json:"update,omitempty"`
 }
 

--- a/clientsession.go
+++ b/clientsession.go
@@ -572,7 +572,6 @@ func (s *ClientSession) sendOffer(client McuClient, sender string, streamType st
 		RoomType: streamType,
 		Payload:  offer,
 		Sid:      client.Sid(),
-		Update:   true,
 	}
 	offer_data, err := json.Marshal(offer_message)
 	if err != nil {

--- a/clientsession.go
+++ b/clientsession.go
@@ -571,6 +571,7 @@ func (s *ClientSession) sendOffer(client McuClient, sender string, streamType st
 		Type:     "offer",
 		RoomType: streamType,
 		Payload:  offer,
+		Sid:      client.Sid(),
 		Update:   true,
 	}
 	offer_data, err := json.Marshal(offer_message)
@@ -601,6 +602,7 @@ func (s *ClientSession) sendCandidate(client McuClient, sender string, streamTyp
 		Payload: map[string]interface{}{
 			"candidate": candidate,
 		},
+		Sid: client.Sid(),
 	}
 	candidate_data, err := json.Marshal(candidate_message)
 	if err != nil {
@@ -696,6 +698,9 @@ func (s *ClientSession) OnIceCompleted(client McuClient) {
 
 	// An empty candidate signals the end of candidates.
 	// s.OnIceCandidate(client, nil)
+}
+
+func (s *ClientSession) SubscriberSidUpdated(subscriber McuSubscriber) {
 }
 
 func (s *ClientSession) PublisherClosed(publisher McuPublisher) {
@@ -876,7 +881,7 @@ func (s *ClientSession) GetOrCreatePublisher(ctx context.Context, mcu Mcu, strea
 			}
 		}
 		var err error
-		publisher, err = mcu.NewPublisher(ctx, s, s.PublicId(), streamType, bitrate, mediaTypes, client)
+		publisher, err = mcu.NewPublisher(ctx, s, s.PublicId(), data.Sid, streamType, bitrate, mediaTypes, client)
 		s.mu.Lock()
 		if err != nil {
 			return nil, err

--- a/hub.go
+++ b/hub.go
@@ -1841,11 +1841,11 @@ func (h *Hub) processMcuMessage(senderSession *ClientSession, session *ClientSes
 			return
 		}
 
-		h.sendMcuMessageResponse(session, message, data, response)
+		h.sendMcuMessageResponse(session, mc, message, data, response)
 	})
 }
 
-func (h *Hub) sendMcuMessageResponse(session *ClientSession, message *MessageClientMessage, data *MessageClientMessageData, response map[string]interface{}) {
+func (h *Hub) sendMcuMessageResponse(session *ClientSession, mcuClient McuClient, message *MessageClientMessage, data *MessageClientMessageData, response map[string]interface{}) {
 	var response_message *ServerMessage
 	switch response["type"] {
 	case "answer":
@@ -1855,6 +1855,7 @@ func (h *Hub) sendMcuMessageResponse(session *ClientSession, message *MessageCli
 			Type:     "answer",
 			RoomType: data.RoomType,
 			Payload:  response,
+			Sid:      mcuClient.Sid(),
 		}
 		answer_data, err := json.Marshal(answer_message)
 		if err != nil {
@@ -1879,6 +1880,7 @@ func (h *Hub) sendMcuMessageResponse(session *ClientSession, message *MessageCli
 			Type:     "offer",
 			RoomType: data.RoomType,
 			Payload:  response,
+			Sid:      mcuClient.Sid(),
 		}
 		offer_data, err := json.Marshal(offer_message)
 		if err != nil {

--- a/mcu_common.go
+++ b/mcu_common.go
@@ -55,6 +55,8 @@ type McuListener interface {
 	OnIceCandidate(client McuClient, candidate interface{})
 	OnIceCompleted(client McuClient)
 
+	SubscriberSidUpdated(subscriber McuSubscriber)
+
 	PublisherClosed(publisher McuPublisher)
 	SubscriberClosed(subscriber McuSubscriber)
 }
@@ -73,12 +75,13 @@ type Mcu interface {
 
 	GetStats() interface{}
 
-	NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, bitrate int, mediaTypes MediaType, initiator McuInitiator) (McuPublisher, error)
+	NewPublisher(ctx context.Context, listener McuListener, id string, sid string, streamType string, bitrate int, mediaTypes MediaType, initiator McuInitiator) (McuPublisher, error)
 	NewSubscriber(ctx context.Context, listener McuListener, publisher string, streamType string) (McuSubscriber, error)
 }
 
 type McuClient interface {
 	Id() string
+	Sid() string
 	StreamType() string
 
 	Close(ctx context.Context)

--- a/mcu_proxy.go
+++ b/mcu_proxy.go
@@ -185,6 +185,7 @@ func (p *mcuProxyPublisher) SendMessage(ctx context.Context, message *MessageCli
 		Payload: &PayloadProxyClientMessage{
 			Type:     data.Type,
 			ClientId: p.proxyId,
+			Sid:      data.Sid,
 			Payload:  data.Payload,
 		},
 	}
@@ -261,6 +262,7 @@ func (s *mcuProxySubscriber) SendMessage(ctx context.Context, message *MessageCl
 		Payload: &PayloadProxyClientMessage{
 			Type:     data.Type,
 			ClientId: s.proxyId,
+			Sid:      data.Sid,
 			Payload:  data.Payload,
 		},
 	}

--- a/mcu_test.go
+++ b/mcu_test.go
@@ -67,7 +67,7 @@ func (m *TestMCU) GetStats() interface{} {
 	return nil
 }
 
-func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id string, streamType string, bitrate int, mediaTypes MediaType, initiator McuInitiator) (McuPublisher, error) {
+func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id string, sid string, streamType string, bitrate int, mediaTypes MediaType, initiator McuInitiator) (McuPublisher, error) {
 	var maxBitrate int
 	if streamType == streamTypeScreen {
 		maxBitrate = TestMaxBitrateScreen
@@ -82,6 +82,7 @@ func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id str
 	pub := &TestMCUPublisher{
 		TestMCUClient: TestMCUClient{
 			id:         id,
+			sid:        sid,
 			streamType: streamType,
 		},
 
@@ -122,11 +123,16 @@ type TestMCUClient struct {
 	closed int32
 
 	id         string
+	sid        string
 	streamType string
 }
 
 func (c *TestMCUClient) Id() string {
 	return c.id
+}
+
+func (c *TestMCUClient) Sid() string {
+	return c.sid
 }
 
 func (c *TestMCUClient) StreamType() string {

--- a/proxy/proxy_server.go
+++ b/proxy/proxy_server.go
@@ -789,6 +789,7 @@ func (s *ProxyServer) processPayload(ctx context.Context, client *ProxyClient, s
 	case "candidate":
 		mcuData = &signaling.MessageClientMessageData{
 			Type:    payload.Type,
+			Sid:     payload.Sid,
 			Payload: payload.Payload,
 		}
 	case "endOfCandidates":
@@ -807,6 +808,7 @@ func (s *ProxyServer) processPayload(ctx context.Context, client *ProxyClient, s
 	case "sendoffer":
 		mcuData = &signaling.MessageClientMessageData{
 			Type: payload.Type,
+			Sid:  payload.Sid,
 		}
 	default:
 		session.sendMessage(message.NewErrorServerMessage(UnsupportedPayload))

--- a/proxy/proxy_server.go
+++ b/proxy/proxy_server.go
@@ -638,7 +638,7 @@ func (s *ProxyServer) processCommand(ctx context.Context, client *ProxyClient, s
 		}
 
 		id := uuid.New().String()
-		publisher, err := s.mcu.NewPublisher(ctx, session, id, cmd.StreamType, cmd.Bitrate, cmd.MediaTypes, &emptyInitiator{})
+		publisher, err := s.mcu.NewPublisher(ctx, session, id, cmd.Sid, cmd.StreamType, cmd.Bitrate, cmd.MediaTypes, &emptyInitiator{})
 		if err == context.DeadlineExceeded {
 			log.Printf("Timeout while creating %s publisher %s for %s", cmd.StreamType, id, session.PublicId())
 			session.sendMessage(message.NewErrorServerMessage(TimeoutCreatingPublisher))
@@ -685,7 +685,8 @@ func (s *ProxyServer) processCommand(ctx context.Context, client *ProxyClient, s
 			Id:   message.Id,
 			Type: "command",
 			Command: &signaling.CommandProxyServerMessage{
-				Id: id,
+				Id:  id,
+				Sid: subscriber.Sid(),
 			},
 		}
 		session.sendMessage(response)

--- a/proxy/proxy_session.go
+++ b/proxy/proxy_session.go
@@ -192,6 +192,24 @@ func (s *ProxySession) OnIceCompleted(client signaling.McuClient) {
 	s.sendMessage(msg)
 }
 
+func (s *ProxySession) SubscriberSidUpdated(subscriber signaling.McuSubscriber) {
+	id := s.proxy.GetClientId(subscriber)
+	if id == "" {
+		log.Printf("Received subscriber sid updated event from unknown %s subscriber %s (%+v)", subscriber.StreamType(), subscriber.Id(), subscriber)
+		return
+	}
+
+	msg := &signaling.ProxyServerMessage{
+		Type: "event",
+		Event: &signaling.EventProxyServerMessage{
+			Type:     "subscriber-sid-updated",
+			ClientId: id,
+			Sid:      subscriber.Sid(),
+		},
+	}
+	s.sendMessage(msg)
+}
+
 func (s *ProxySession) PublisherClosed(publisher signaling.McuPublisher) {
 	if id := s.DeletePublisher(publisher); id != "" {
 		if s.proxy.DeleteClient(id, publisher) {


### PR DESCRIPTION
Follow up to #195

The WebUI of Talk sends a `sid` parameter in all the messages for an RTCPeerConnection to identify it (this has been there since the beginning, as it was implemented by SimpleWebRTC). Although that message is accepted by the mobile apps and the standalone signaling server they do nothing with it; they did not generate their own `sid` when needed (when they started the connection), and the messages sent by them did not contain the `sid` parameter either.

This pull request adds the `sid` parameter to the signaling server messages. The `sid` is set by the clients for publishers and by the signaling server for subscribers. Note that the `sid` is not propagated from publishers to subscribers, as they are different connections; the signaling server sets the `sid` for a subscriber from the Janus handle of the subscriber.

The mobile apps need to be updated for Talk 14 to get support for renegotiations, so they will be modified also to create and handle the `sid` as needed. Nevertheles, this change should be backwards compatible even with older versions in which they do not handle the `sid`: they already accepted it in incoming messages due to being sent by the WebUI, and if no `sid` is provided for publishers the signaling server will set it as empty and omit it the messages sent by it.

Note that I used `sid` everywhere for consistency... and because I did not know what other name to use :-P If you find a better name I would be more than happy to change it ;-)

In #195 an `update` parameter was added so [the clients could distinguish between an offer for a new connection and an offer for an existing connection](https://github.com/strukturag/nextcloud-spreed-signaling/pull/195#discussion_r804669847). However, that parameter only says that the offer is an update of the current connection, but it does not say which one is the current connection, so it only adddresses the issue in half. Turns out that the `sid` parameter makes the `update` parameter obsolete, as with the `sid` it can be known the connection that the message belongs to. Therefore the `update` parameter was removed.

Besides that, the signaling server now also ignores offer/answer messages (and thus also candidates) if the `sid` in the message does not match the `sid` of the publisher or subscriber that is meant to receive it. Nevertheless, if a message does not contain a `sid` parameter the message is handled just like before for backwards compatibility.

I tested this with and without proxies and, as far as I can tell, it works. But please review carefully, as I felt like a monkey with a keyboard when figuring out what to change and where :-P
