### PR TITLE
Support toggling audio/video in subscribed streams.

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -1903,9 +1903,7 @@ func (h *Hub) sendMcuMessageResponse(session *ClientSession, mcuClient McuClient
 		return
 	}
 
-	if response_message != nil {
-		session.SendMessage(response_message)
-	}
+	session.SendMessage(response_message)
 }
 
 func (h *Hub) processByeMsg(client *Client, message *ClientMessage) {


### PR DESCRIPTION
Follow-up to #191 

The command `selectStream` also supports optional boolean flags `audio` and `video` that can be used to enable/disable receiving the corresponding media from the stream. The parameters of `selectStream` can also be included in the payload of `requestoffer` for example to subscribe a stream with video initially disabled.

The new flags are similar to the existing `substream` / `temporal`.

@danxuliu please review, is this something you could work with?