### PR TITLE
Fix "signaling_server_messages_total" stat not being incremented

### DIFF
--- a/hub.go
+++ b/hub.go
@@ -816,6 +816,8 @@ func (h *Hub) processMessage(client *Client, data []byte) {
 		return
 	}
 
+	statsMessagesTotal.WithLabelValues(message.Type).Inc()
+
 	session := client.GetSession()
 	if session == nil {
 		if message.Type != "hello" {


### PR DESCRIPTION
Follow up to #99 

Although the [server stats were registered](https://github.com/strukturag/nextcloud-spreed-signaling/blob/614c5f6e21ac59775b063454341f05033d259284/server/main.go#L144) `signaling_server_messages_total` was not incremented.

I have added the increment in `processMessage` in _hub.go_ (and only for successful messages), but I do not know if it is the right place, so please adjust it if needed :-) Thanks!