### PR TITLE
dist: add systemd sysusers file

### DIFF
--- a/dist/init/systemd/sysusers.d/signaling.conf
+++ b/dist/init/systemd/sysusers.d/signaling.conf
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Andrea Pappacoda <andrea@pappacoda.it>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+u signaling - "nextcloud-spreed-signaling user"


### PR DESCRIPTION
The systemd unit makes use of the user "signaling", but it is not created in any way, so the directive is ignored.

By creating a sysusers file it is possible to tell the system to create a "signaling" user so that the directive is honoured.

For more information, see the sysusers.d manpage, at https://www.freedesktop.org/software/systemd/man/sysusers.d.html

This is mainly useful on systems running systemd, but the sysusers concept is implemented also by other projects that don't use systemd, like opensysusers, originated from Artix Linux.