### PR TITLE
dist: harden systemd service unit

### DIFF
--- a/dist/init/systemd/signaling.service
+++ b/dist/init/systemd/signaling.service
@@ -7,5 +7,37 @@ User=signaling
 Group=signaling
 Restart=on-failure
 
+# Makes sure that /etc/signaling is owned by this service
+ConfigurationDirectory=signaling
+
+# Hardening - see systemd.exec(5)
+CapabilityBoundingSet=
+ExecPaths=/usr/bin/signaling /usr/lib
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+NoExecPaths=/
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateTmp=yes
+PrivateUsers=yes
+ProcSubset=pid
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+SystemCallFilter=@system-service
+SystemCallFilter=~ @privileged @resources
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With this patch the systemd service will now run in a hardened sandbox that limits the kinds of subsystems available to the unit. This improves the overall security of the system, as nextcloud-spreed-signaling becomes almost pointless to exploit.

The most notable changes include:

- The entire fie system is mounted read-only with `ProtectSystem=strict`
- No binaries are executable, apart from `/usr/bin/signaling`, with `NoExecPaths=/` and `ExecPaths=/usr/bin/signaling`
- The service cannot see any user on the system apart from the one that is running the process, with `PrivateUsers=yes`
- Most of the `/proc` subsystem is inaccessible, and things like system stats may be unavailabe, with `ProcSubset=pid`
- All home directories are inaccessible, with `ProtectHome=yes`
- The kinds of permitted system calls are limited, via `SystemCallFilter=`

I highly recommend you to read the [systemd.exec(5)](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) manual page to fully understand what these options do and how they can protect the system.

Unfortunately I haven't been running nextcloud-spreed-signaling in a while, and I can't currently check that these option do not break functionality. I have tested this in a limited environment and it seems that everything still works fine, but it would be better to also check that e.g. the Janus integration is still functional in this hardened sandbox.