### PR TITLE
Send initial "welcome" message when clients connect.

### DIFF
--- a/api_proxy.go
+++ b/api_proxy.go
@@ -156,8 +156,8 @@ func (m *HelloProxyClientMessage) CheckValid() error {
 type HelloProxyServerMessage struct {
 	Version string `json:"version"`
 
-	SessionId string                    `json:"sessionid"`
-	Server    *HelloServerMessageServer `json:"server,omitempty"`
+	SessionId string                `json:"sessionid"`
+	Server    *WelcomeServerMessage `json:"server,omitempty"`
 }
 
 // Type "bye"

--- a/api_signaling_test.go
+++ b/api_signaling_test.go
@@ -24,6 +24,8 @@ package signaling
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
 	"testing"
 )
 
@@ -345,4 +347,43 @@ func TestIsChatRefresh(t *testing.T) {
 	if msg.IsChatRefresh() {
 		t.Error("message should not be detected as chat refresh")
 	}
+}
+
+func assertEqualStrings(t *testing.T, expected, result []string) {
+	t.Helper()
+
+	if expected == nil {
+		expected = make([]string, 0)
+	} else {
+		sort.Strings(expected)
+	}
+	if result == nil {
+		result = make([]string, 0)
+	} else {
+		sort.Strings(result)
+	}
+
+	if !reflect.DeepEqual(expected, result) {
+		t.Errorf("Expected %+v, got %+v", expected, result)
+	}
+}
+
+func Test_Welcome_AddRemoveFeature(t *testing.T) {
+	var msg WelcomeServerMessage
+	assertEqualStrings(t, []string{}, msg.Features)
+
+	msg.AddFeature("one", "two", "one")
+	assertEqualStrings(t, []string{"one", "two"}, msg.Features)
+	if !sort.StringsAreSorted(msg.Features) {
+		t.Errorf("features should be sorted, got %+v", msg.Features)
+	}
+
+	msg.AddFeature("three")
+	assertEqualStrings(t, []string{"one", "two", "three"}, msg.Features)
+	if !sort.StringsAreSorted(msg.Features) {
+		t.Errorf("features should be sorted, got %+v", msg.Features)
+	}
+
+	msg.RemoveFeature("three", "one")
+	assertEqualStrings(t, []string{"two"}, msg.Features)
 }

--- a/docs/standalone-signaling-api-v1.md
+++ b/docs/standalone-signaling-api-v1.md
@@ -111,6 +111,23 @@ must contain two additional HTTP headers:
 - Calculated checksum: `3c4a69ff328299803ac2879614b707c807b4758cf19450755c60656cac46e3bc`
 
 
+## Welcome message
+
+When a client connects, the server will immediately send a `welcome` message to
+notify the client about supported features. This is available if the server
+supports the `welcome` feature id.
+
+Message format (Server -> Client):
+
+    {
+      "type": "welcome",
+      "welcome": {
+        "features": ["optional", "list, "of", "feature", "ids"],
+        ...additional information about the server...
+      }
+    }
+
+
 ## Establish connection
 
 This must be the first request by a newly connected client and is used to
@@ -149,6 +166,10 @@ Message format (Server -> Client):
         }
       }
     }
+
+Please note that the `server` entry is deprecated and will be removed in a
+future version. Clients should use the data from the
+[`welcome` message](#welcome-message) instead.
 
 
 ### Backend validation

--- a/hub_test.go
+++ b/hub_test.go
@@ -473,6 +473,29 @@ func performHousekeeping(hub *Hub, now time.Time) *sync.WaitGroup {
 	return &wg
 }
 
+func TestInitialWelcome(t *testing.T) {
+	hub, _, _, server := CreateHubForTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client := NewTestClientContext(ctx, t, server, hub)
+	defer client.CloseWithBye()
+
+	msg, err := client.RunUntilMessage(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if msg.Type != "welcome" {
+		t.Errorf("Expected \"welcome\" message, got %+v", msg)
+	} else if msg.Welcome.Version == "" {
+		t.Errorf("Expected welcome version, got %+v", msg)
+	} else if len(msg.Welcome.Features) == 0 {
+		t.Errorf("Expected welcome features, got %+v", msg)
+	}
+}
+
 func TestExpectClientHello(t *testing.T) {
 	hub, _, _, server := CreateHubForTest(t)
 

--- a/proxy/proxy_server.go
+++ b/proxy/proxy_server.go
@@ -591,7 +591,7 @@ func (s *ProxyServer) processMessage(client *ProxyClient, data []byte) {
 			Hello: &signaling.HelloProxyServerMessage{
 				Version:   signaling.HelloVersion,
 				SessionId: session.PublicId(),
-				Server: &signaling.HelloServerMessageServer{
+				Server: &signaling.WelcomeServerMessage{
 					Version: s.version,
 					Country: s.country,
 				},


### PR DESCRIPTION
This can be used to detect server features before performing the actual "hello" handshake.

Implements #273