### PR TITLE
etcd: Fix race in initialized event.

### DIFF
--- a/etcd_client.go
+++ b/etcd_client.go
@@ -41,6 +41,7 @@ type EtcdClientListener interface {
 }
 
 type EtcdClientWatcher interface {
+	EtcdWatchCreated(client *EtcdClient, key string)
 	EtcdKeyUpdated(client *EtcdClient, key string, value []byte)
 	EtcdKeyDeleted(client *EtcdClient, key string)
 }
@@ -242,6 +243,7 @@ func (c *EtcdClient) Watch(ctx context.Context, key string, watcher EtcdClientWa
 	log.Printf("Wait for leader and start watching on %s", key)
 	ch := c.getEtcdClient().Watch(clientv3.WithRequireLeader(ctx), key, opts...)
 	log.Printf("Watch created for %s", key)
+	watcher.EtcdWatchCreated(c, key)
 	for response := range ch {
 		if err := response.Err(); err != nil {
 			return err

--- a/mcu_proxy.go
+++ b/mcu_proxy.go
@@ -1561,6 +1561,9 @@ func (m *mcuProxy) EtcdClientCreated(client *EtcdClient) {
 	}()
 }
 
+func (m *mcuProxy) EtcdWatchCreated(client *EtcdClient, key string) {
+}
+
 func (m *mcuProxy) getProxyUrls(client *EtcdClient, keyPrefix string) (*clientv3.GetResponse, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()


### PR DESCRIPTION
It could happen that the initialized event was triggered even though the watch was not fully created yet.