### PR TITLE
Switch to apt-get on CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.18 AS builder
 WORKDIR /workdir
 
 COPY . .
-RUN apt -y update && apt -y install protobuf-compiler
+RUN apt-get -y update && apt-get -y install protobuf-compiler
 RUN make build
 
 FROM alpine:3.15


### PR DESCRIPTION
`apt` does not have a stable CLI interface