### PR TITLE
remove @resources from SystemCallFilter

### DIFF
--- a/dist/init/systemd/signaling.service
+++ b/dist/init/systemd/signaling.service
@@ -37,7 +37,7 @@ RestrictRealtime=yes
 RestrictSUIDSGID=yes
 SystemCallArchitectures=native
 SystemCallFilter=@system-service
-SystemCallFilter=~ @privileged @resources
+SystemCallFilter=~ @privileged
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Introduced in https://github.com/strukturag/nextcloud-spreed-signaling/pull/276.

* https://gitlab.com/packaging/nextcloud-spreed-signaling/-/commit/3fcaf45b6f32276ad1c42d0ff6a337db4d66da79#note_1055183029
* https://github.com/nextcloud/vm/issues/2371
* https://github.com/strukturag/nextcloud-spreed-signaling/issues/315

As @Tachi107 left a comment about `ProcSubset`, i tested the other way around and leave ´@resources` in place while removing `ProcSubset=pid`, still does not work.