### PR TITLE
Explicitly use type "sysConn".

### DIFF
--- a/syscallconn.go
+++ b/syscallconn.go
@@ -47,12 +47,12 @@ type syscallConn struct {
 //
 // This function returns newConn if rawConn doesn't implement syscall.Conn.
 func WrapSyscallConn(rawConn, newConn net.Conn) net.Conn {
-	sysConn, ok := rawConn.(syscall.Conn)
+	sc, ok := rawConn.(sysConn)
 	if !ok {
 		return newConn
 	}
 	return &syscallConn{
 		Conn:    newConn,
-		sysConn: sysConn,
+		sysConn: sc,
 	}
 }


### PR DESCRIPTION
Fixes error with newer versions of golangci-lint.