### PR TITLE
Allow SKIP_VERIFY in docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -64,6 +64,7 @@ The running container can be configured through different environment variables:
 - `GRPC_DNS_DISCOVERY`: Enable DNS discovery on hostnames of configured GRPC targets.
 - `GRPC_ETCD`: Set to `1` if etcd should be used to configure GRPC peers.
 - `GRPC_TARGET_PREFIX`: Key prefix of GRPC target entries.
+- `SKIP_VERIFY`: Set to `true` to skip certificate validation of backends and proxy servers. This should only be enabled during development, e.g. to work with self-signed certificates.
 
 Example with two backends:
 

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -127,6 +127,10 @@ if [ ! -f "$CONFIG" ]; then
     sed -i "s|#maxscreenbitrate =.*|maxscreenbitrate = $MAX_SCREEN_BITRATE|" "$CONFIG"
   fi
 
+  if [ ! -z "$SKIP_VERIFY" ]; then
+    sed -i "s|#skipverify =.*|skipverify = $SKIP_VERIFY|" "$CONFIG"
+  fi 
+
   if [ ! -z "$TURN_API_KEY" ]; then
     sed -i "s|#apikey = the-api-key-for-the-rest-service|apikey = $TURN_API_KEY|" "$CONFIG"
   fi


### PR DESCRIPTION
To allow using the official docker image of the signaling server for development as well, it would be nice to add `SKIP_VERIFY` as an environment option as well. 

If this was purposely not added, because it's considered a development option, feel free to just close this.