### PR TITLE
TURN_API_KEY  and TURN_SECRET fix

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -128,10 +128,10 @@ if [ ! -f "$CONFIG" ]; then
   fi
 
   if [ ! -z "$TURN_API_KEY" ]; then
-    sed -i "s|#apikey = the-api-key-for-the-rest-service|apikey = $TURN_API_KEY|" "$CONFIG"
+    sed -i "s|#apikey =.*|apikey = $TURN_API_KEY|" "$CONFIG"
   fi
   if [ ! -z "$TURN_SECRET" ]; then
-    sed -i "s|#secret = 6d1c17a7-c736-4e22-b02c-e2955b7ecc64|secret = $TURN_SECRET|" "$CONFIG"
+    sed -i "s|#secret =.*|secret = $TURN_SECRET|" "$CONFIG"
   fi
   if [ ! -z "$TURN_SERVERS" ]; then
     sed -i "s|#servers =.*|servers = $TURN_SERVERS|" "$CONFIG"


### PR DESCRIPTION
sry , my last fix wasn't consistent to the other replacements now we can update not only the default value of TURN_API_KEY and TURN_SECRET

some note:
maybe someone can change the TURN_SECRET value "secret" in something like "turnsecret" to not run into trouble with other "secret" value(s) in the backend section.