### PR TITLE
docker: Don't rely on default values when updating TURN settings.

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -129,13 +129,13 @@ if [ ! -f "$CONFIG" ]; then
 
   if [ ! -z "$SKIP_VERIFY" ]; then
     sed -i "s|#skipverify =.*|skipverify = $SKIP_VERIFY|" "$CONFIG"
-  fi 
+  fi
 
   if [ ! -z "$TURN_API_KEY" ]; then
-    sed -i "s|#apikey = the-api-key-for-the-rest-service|apikey = $TURN_API_KEY|" "$CONFIG"
+    sed -i "s|#\?apikey =.*|apikey = $TURN_API_KEY|" "$CONFIG"
   fi
   if [ ! -z "$TURN_SECRET" ]; then
-    sed -i "s|#secret = 6d1c17a7-c736-4e22-b02c-e2955b7ecc64|secret = $TURN_SECRET|" "$CONFIG"
+    sed -i "/same as on the TURN server/{n;s|#\?secret =.*|secret = $TURN_SECRET|}" "$CONFIG"
   fi
   if [ ! -z "$TURN_SERVERS" ]; then
     sed -i "s|#servers =.*|servers = $TURN_SERVERS|" "$CONFIG"


### PR DESCRIPTION
Replaces #432

@3x3cut0r Please test, this is better than your change as it won't replace other `secret`  values in the config files.