### PR TITLE
Offer more video codecs for Janus rooms

### DIFF
--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -734,10 +734,13 @@ func (m *mcuJanus) getOrCreatePublisherHandle(ctx context.Context, id string, st
 		"publishers": 1,
 		// Do not use the video-orientation RTP extension as it breaks video
 		// orientation changes in Firefox.
-		"videoorient_ext": false,
-		// Offer more video & audio codecs
-		"audiocodec": "opus,g722,pcmu,pcma,isac32",
-		"videocodec": "vp9,h265,vp8,h264,av1",
+                // "videoorient_ext": false,
+                // Offer more video & audio codecs
+                "audiocodec": "opus,g722,pcmu,pcma,isac32",
+                "videocodec": "av1,vp9,vp8,h265,h264",
+                "video_svc": true,
+                "vp9_profile": "2",
+                "h264_profile": "42e01f",
 	}
 	var maxBitrate int
 	if streamType == streamTypeScreen {

--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -738,7 +738,6 @@ func (m *mcuJanus) getOrCreatePublisherHandle(ctx context.Context, id string, st
 		// Offer more video & audio codecs
 		"audiocodec": "opus,g722,pcmu,pcma,isac32",
 		"videocodec": "vp9,h264,h265,vp8,av1",
-        }
 	}
 	var maxBitrate int
 	if streamType == streamTypeScreen {

--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -737,7 +737,7 @@ func (m *mcuJanus) getOrCreatePublisherHandle(ctx context.Context, id string, st
 		"videoorient_ext": false,
 		// Offer more video & audio codecs
 		"audiocodec": "opus,g722,pcmu,pcma,isac32",
-		"videocodec": "vp9,vp8,h265,h264,av1",
+		"videocodec": "vp9,h265,vp8,h264,av1",
 	}
 	var maxBitrate int
 	if streamType == streamTypeScreen {

--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -737,7 +737,7 @@ func (m *mcuJanus) getOrCreatePublisherHandle(ctx context.Context, id string, st
 		"videoorient_ext": false,
 		// Offer more video & audio codecs
 		"audiocodec": "opus,g722,pcmu,pcma,isac32",
-		"videocodec": "vp9,h264,h265,vp8,av1",
+		"videocodec": "h265,vp9,h264,vp8,av1",
 	}
 	var maxBitrate int
 	if streamType == streamTypeScreen {

--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -737,7 +737,7 @@ func (m *mcuJanus) getOrCreatePublisherHandle(ctx context.Context, id string, st
 		"videoorient_ext": false,
 		// Offer more video & audio codecs
 		"audiocodec": "opus,g722,pcmu,pcma,isac32",
-		"videocodec": "h265,vp9,h264,vp8,av1",
+		"videocodec": "vp9,vp8,h265,h264,av1",
 	}
 	var maxBitrate int
 	if streamType == streamTypeScreen {


### PR DESCRIPTION
Looking at this issue here: https://github.com/strukturag/nextcloud-spreed-signaling/issues/79
and the example config of Janus https://github.com/meetecho/janus-gateway/blob/master/conf/janus.plugin.videoroom.jcfg.sample I made these small changes.
Works locally for me with my docker compose setup.

Note: I am using a newer version of Janus, v1.1.3