### PR TITLE
Simplify vendoring.

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Extract tarball
       run: |
         mkdir -p tmp
-        tar xf nextcloud-spreed-signaling*.tar.gz --strip-components=1 -C tmp
+        tar xvf nextcloud-spreed-signaling*.tar.gz --strip-components=1 -C tmp
         [ -d "tmp/vendor" ] || exit 1
 
     - name: Build

--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,6 @@ TARVERSION := $(shell "$(CURDIR)/scripts/get-version.sh" --tar)
 PACKAGENAME := github.com/strukturag/nextcloud-spreed-signaling
 ALL_PACKAGES := $(PACKAGENAME) $(PACKAGENAME)/client $(PACKAGENAME)/proxy $(PACKAGENAME)/server
 
-PROTOC_GEN_GRPC_VERSION := v1.3.0
-
 ifneq ($(VERSION),)
 INTERNALLDFLAGS := -X main.version=$(VERSION)
 else
@@ -148,21 +146,8 @@ build: server proxy
 vendor: go.mod go.sum common
 	set -e ;\
 	rm -rf $(VENDORDIR)
-	EASYJSON_DIR=$$($(GO) list -m -f '{{.Dir}}' github.com/mailru/easyjson); \
-	PROTOBUF_DIR=$$($(GO) list -m -f '{{.Dir}}' google.golang.org/protobuf); \
 	$(GO) mod tidy; \
-	$(GO) mod vendor; \
-	mkdir -p $(VENDORDIR)/github.com/mailru/easyjson/; \
-	cp -rf --no-preserve=mode $$EASYJSON_DIR/easyjson/ $(VENDORDIR)/github.com/mailru/easyjson/; \
-	mkdir -p $(VENDORDIR)/google.golang.org/grpc/cmd/protoc-gen-go-grpc/; \
-	[ -d "$(GOPATH)/pkg/mod/google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GRPC_VERSION)" ] || echo "Folder for protoc-gen-go-grpc command does not exist, please check Makefile."; \
-	[ -d "$(GOPATH)/pkg/mod/google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GRPC_VERSION)" ] || exit 1; \
-	cp -rf --no-preserve=mode $(GOPATH)/pkg/mod/google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GRPC_VERSION)/* $(VENDORDIR)/google.golang.org/grpc/cmd/protoc-gen-go-grpc/; \
-	cp -rf --no-preserve=mode $$PROTOBUF_DIR/cmd/ $(VENDORDIR)/google.golang.org/protobuf/; \
-	cp -rf --no-preserve=mode $$PROTOBUF_DIR/internal/ $(VENDORDIR)/google.golang.org/protobuf/; \
-	cp -rf --no-preserve=mode $$PROTOBUF_DIR/reflect/ $(VENDORDIR)/google.golang.org/protobuf/; \
-	find $(VENDORDIR)/google.golang.org/protobuf/ -name "*_test.go" -delete; \
-	find $(VENDORDIR)/google.golang.org/protobuf/ -name "testdata" | xargs rm -r; \
+	$(GO) mod vendor
 
 tarball: vendor
 	git archive \

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.etcd.io/etcd/client/v3 v3.5.7
 	go.etcd.io/etcd/server/v3 v3.5.7
 	google.golang.org/grpc v1.53.0
+	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -622,6 +622,8 @@ google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.41.0/go.mod h1:U3l9uK9J0sini8mHphKoXyaqDA/8VyGnDee1zzIUK6k=
 google.golang.org/grpc v1.53.0 h1:LAv2ds7cmFV/XTS3XG1NneeENYrXGmorPxsBbptIjNc=
 google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0 h1:rNBFJjBCOgVr9pWD7rs/knKL4FRTKgpZmsRfV214zcA=
+google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0/go.mod h1:Dk1tviKTvMCz5tvh7t+fh94dhmQVHuCt2OzJB3CTW9Y=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/tools.go
+++ b/tools.go
@@ -1,6 +1,8 @@
+//go:build tools
+
 /**
  * Standalone signaling server for the Nextcloud Spreed app.
- * Copyright (C) 2022 struktur AG
+ * Copyright (C) 2023 struktur AG
  *
  * @author Joachim Bauch <bauch@struktur.de>
  *
@@ -21,11 +23,9 @@
  */
 package signaling
 
-// Import modules that would otherwise not be detected by "go mod vendor".
+// Import applications that would otherwise not be detected by "go mod vendor".
 import (
-	_ "github.com/mailru/easyjson"
-	_ "github.com/mailru/easyjson/bootstrap"
-	_ "github.com/mailru/easyjson/gen"
-	_ "github.com/mailru/easyjson/parser"
-	_ "google.golang.org/protobuf/compiler/protogen"
+	_ "github.com/mailru/easyjson/easyjson"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
Instead of manually copying files to vendor folder, try to get "go" to detect dependencies instead.