### PR TITLE
Add allowall to docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -21,6 +21,8 @@ The running container can be configured through different environment variables:
 - `HASH_KEY`: Secret value used to generate checksums of sessions (32 or 64 bytes).
 - `BLOCK_KEY`: Key for encrypting data in the sessions (16, 24 or 32 bytes).
 - `INTERNAL_SHARED_SECRET_KEY`: Shared secret for connections from internal clients.
+- `BACKENDS_ALLOWALL`: Allow all backends. Extremly insecure - use only for development!
+- `BACKENDS_ALLOWALL_SECRET`: Secret when `BACKENDS_ALLOWALL` is enabled.
 - `BACKENDS`: Space-separated list of backend ids.
 - `BACKEND_<ID>_URL`: Url of backend `ID` (where `ID` is the uppercase backend id).
 - `BACKEND_<ID>_SHARED_SECRET`: Shared secret for backend `ID` (where `ID` is the uppercase backend id).

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -215,6 +215,14 @@ if [ ! -f "$CONFIG" ]; then
     echo >> "$CONFIG"
   fi
 
+  if [ ! -z "$BACKENDS_ALLOWALL" ]; then
+    sed -i "s|allowall = false|allowall = $BACKENDS_ALLOWALL|" "$CONFIG"
+  fi
+
+  if [ ! -z "$BACKENDS_ALLOWALL_SECRET" ]; then
+    sed -i "s|#secret = the-shared-secret-for-allowall|secret = $BACKENDS_ALLOWALL_SECRET|" "$CONFIG"
+  fi  
+
   if [ ! -z "$BACKENDS" ]; then
     sed -i "s|#backends = .*|backends = $BACKENDS|" "$CONFIG"
 

--- a/server.conf.in
+++ b/server.conf.in
@@ -89,7 +89,7 @@ allowall = false
 # Common shared secret for requests from and to the backend servers if
 # "allowall" is enabled. This must be the same value as configured in the
 # Nextcloud admin ui.
-#secret = the-shared-secret
+#secret = the-shared-secret-for-allowall
 
 # Timeout in seconds for requests to the backend.
 timeout = 10


### PR DESCRIPTION
For easier work in a development environment (e.g. https://github.com/juliushaertl/nextcloud-docker-dev) it would be nice if we could set the `allowall` property directly in the docker image.