### PR TITLE
Follow the Go release policy by supporting only the last two versions.

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
           - "1.19"
           - "1.20"
     runs-on: ubuntu-latest
@@ -71,7 +70,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
           - "1.19"
           - "1.20"
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.18"
           - "1.19"
           - "1.20"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,9 +17,12 @@ information on the API of the signaling server.
 The following tools are required for building the signaling server.
 
 - git
-- go >= 1.18 (usually the last three versions of go are supported)
+- go >= 1.19
 - make
 - protobuf-compiler >= 3
+
+Usually the last two versions of Go are supported. This follows the release
+policy of Go: https://go.dev/doc/devel/release#policy
 
 All other dependencies are fetched automatically while building.
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strukturag/nextcloud-spreed-signaling
 
-go 1.18
+go 1.19
 
 require (
 	github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490


### PR DESCRIPTION
This removes support for Go 1.18