### PR TITLE
Log warning if no (static) backends have been configured.

### DIFF
--- a/backend_storage_static.go
+++ b/backend_storage_static.go
@@ -115,6 +115,10 @@ func NewBackendStorageStatic(config *goconf.ConfigFile) (BackendStorage, error) 
 		}
 	}
 
+	if numBackends == 0 {
+		log.Printf("WARNING: No backends configured, client connections will not be possible.")
+	}
+
 	statsBackendsCurrent.Add(float64(numBackends))
 	return &backendStorageStatic{
 		backendStorageCommon: backendStorageCommon{


### PR DESCRIPTION
Resolves #528 