### PR TITLE
No longer support Golang 1.19.

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.19"
           - "1.20"
           - "1.21"
     runs-on: ubuntu-latest
@@ -71,7 +70,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.19"
           - "1.20"
           - "1.21"
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.19"
           - "1.20"
           - "1.21"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ information on the API of the signaling server.
 The following tools are required for building the signaling server.
 
 - git
-- go >= 1.19
+- go >= 1.20
 - make
 - protobuf-compiler >= 3
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strukturag/nextcloud-spreed-signaling
 
-go 1.19
+go 1.20
 
 require (
 	github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490


### PR DESCRIPTION
This follows the Go release policy of only supporting the last two versions.