### PR TITLE
CI: Disable cache for linter to bring back annotations.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,3 +40,6 @@ jobs:
         with:
           version: latest
           args: --timeout=2m0s
+          skip-cache: true
+          skip-pkg-cache: true
+          skip-build-cache: true


### PR DESCRIPTION
Previously, extracting the cache caused lots of errors that filled up the log and prevented the annotations from being shown.