### PR TITLE
Update etcd watch handling.

### DIFF
--- a/backend_storage_etcd.go
+++ b/backend_storage_etcd.go
@@ -24,10 +24,10 @@ package signaling
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/url"
-	"sync"
 	"time"
 
 	"github.com/dlintw/goconf"
@@ -43,8 +43,10 @@ type backendStorageEtcd struct {
 
 	initializedCtx       context.Context
 	initializedFunc      context.CancelFunc
-	initializedWg        sync.WaitGroup
 	wakeupChanForTesting chan struct{}
+
+	closeCtx  context.Context
+	closeFunc context.CancelFunc
 }
 
 func NewBackendStorageEtcd(config *goconf.ConfigFile, etcdClient *EtcdClient) (BackendStorage, error) {
@@ -58,6 +60,7 @@ func NewBackendStorageEtcd(config *goconf.ConfigFile, etcdClient *EtcdClient) (B
 	}
 
 	initializedCtx, initializedFunc := context.WithCancel(context.Background())
+	closeCtx, closeFunc := context.WithCancel(context.Background())
 	result := &backendStorageEtcd{
 		backendStorageCommon: backendStorageCommon{
 			backends: make(map[string][]*Backend),
@@ -68,6 +71,8 @@ func NewBackendStorageEtcd(config *goconf.ConfigFile, etcdClient *EtcdClient) (B
 
 		initializedCtx:  initializedCtx,
 		initializedFunc: initializedFunc,
+		closeCtx:        closeCtx,
+		closeFunc:       closeFunc,
 	}
 
 	etcdClient.AddListener(result)
@@ -95,15 +100,12 @@ func (s *backendStorageEtcd) wakeupForTesting() {
 }
 
 func (s *backendStorageEtcd) EtcdClientCreated(client *EtcdClient) {
-	s.initializedWg.Add(1)
 	go func() {
-		if err := client.Watch(context.Background(), s.keyPrefix, s, clientv3.WithPrefix()); err != nil {
-			log.Printf("Error processing watch for %s: %s", s.keyPrefix, err)
-		}
-	}()
+		if err := client.WaitForConnection(s.closeCtx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 
-	go func() {
-		if err := client.WaitForConnection(context.Background()); err != nil {
 			panic(err)
 		}
 
@@ -111,35 +113,43 @@ func (s *backendStorageEtcd) EtcdClientCreated(client *EtcdClient) {
 		if err != nil {
 			panic(err)
 		}
-		for {
-			response, err := s.getBackends(client, s.keyPrefix)
+		for s.closeCtx.Err() == nil {
+			response, err := s.getBackends(s.closeCtx, client, s.keyPrefix)
 			if err != nil {
-				if err == context.DeadlineExceeded {
+				if errors.Is(err, context.Canceled) {
+					return
+				} else if errors.Is(err, context.DeadlineExceeded) {
 					log.Printf("Timeout getting initial list of backends, retry in %s", backoff.NextWait())
 				} else {
 					log.Printf("Could not get initial list of backends, retry in %s: %s", backoff.NextWait(), err)
 				}
 
-				backoff.Wait(context.Background())
+				backoff.Wait(s.closeCtx)
 				continue
 			}
 
 			for _, ev := range response.Kvs {
 				s.EtcdKeyUpdated(client, string(ev.Key), ev.Value)
 			}
-			s.initializedWg.Wait()
 			s.initializedFunc()
+
+			nextRevision := response.Header.Revision + 1
+			for s.closeCtx.Err() == nil {
+				var err error
+				if nextRevision, err = client.Watch(s.closeCtx, s.keyPrefix, nextRevision, s, clientv3.WithPrefix()); err != nil {
+					log.Printf("Error processing watch for %s: %s", s.keyPrefix, err)
+				}
+			}
 			return
 		}
 	}()
 }
 
 func (s *backendStorageEtcd) EtcdWatchCreated(client *EtcdClient, key string) {
-	s.initializedWg.Done()
 }
 
-func (s *backendStorageEtcd) getBackends(client *EtcdClient, keyPrefix string) (*clientv3.GetResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+func (s *backendStorageEtcd) getBackends(ctx context.Context, client *EtcdClient, keyPrefix string) (*clientv3.GetResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
 	return client.Get(ctx, keyPrefix, clientv3.WithPrefix())
@@ -241,6 +251,7 @@ func (s *backendStorageEtcd) EtcdKeyDeleted(client *EtcdClient, key string) {
 
 func (s *backendStorageEtcd) Close() {
 	s.etcdClient.RemoveListener(s)
+	s.closeFunc()
 }
 
 func (s *backendStorageEtcd) Reload(config *goconf.ConfigFile) {

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.etcd.io/etcd/client/pkg/v3 v3.5.12
 	go.etcd.io/etcd/client/v3 v3.5.12
 	go.etcd.io/etcd/server/v3 v3.5.12
+	go.uber.org/zap v1.17.0
 	google.golang.org/grpc v1.63.2
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.3.0
 	google.golang.org/protobuf v1.33.0
@@ -76,7 +77,6 @@ require (
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.19.0 // indirect

--- a/proxy_config_etcd.go
+++ b/proxy_config_etcd.go
@@ -41,6 +41,9 @@ type proxyConfigEtcd struct {
 	keyPrefix string
 	keyInfos  map[string]*ProxyInformationEtcd
 	urlToKey  map[string]string
+
+	closeCtx  context.Context
+	closeFunc context.CancelFunc
 }
 
 func NewProxyConfigEtcd(config *goconf.ConfigFile, etcdClient *EtcdClient, proxy McuProxy) (ProxyConfig, error) {
@@ -48,12 +51,17 @@ func NewProxyConfigEtcd(config *goconf.ConfigFile, etcdClient *EtcdClient, proxy
 		return nil, errors.New("No etcd endpoints configured")
 	}
 
+	closeCtx, closeFunc := context.WithCancel(context.Background())
+
 	result := &proxyConfigEtcd{
 		proxy: proxy,
 
 		client:   etcdClient,
 		keyInfos: make(map[string]*ProxyInformationEtcd),
 		urlToKey: make(map[string]string),
+
+		closeCtx:  closeCtx,
+		closeFunc: closeFunc,
 	}
 	if err := result.configure(config, false); err != nil {
 		return nil, err
@@ -83,17 +91,16 @@ func (p *proxyConfigEtcd) Reload(config *goconf.ConfigFile) error {
 
 func (p *proxyConfigEtcd) Stop() {
 	p.client.RemoveListener(p)
+	p.closeFunc()
 }
 
 func (p *proxyConfigEtcd) EtcdClientCreated(client *EtcdClient) {
 	go func() {
-		if err := client.Watch(context.Background(), p.keyPrefix, p, clientv3.WithPrefix()); err != nil {
-			log.Printf("Error processing watch for %s: %s", p.keyPrefix, err)
-		}
-	}()
+		if err := client.WaitForConnection(p.closeCtx); err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 
-	go func() {
-		if err := client.WaitForConnection(context.Background()); err != nil {
 			panic(err)
 		}
 
@@ -101,23 +108,35 @@ func (p *proxyConfigEtcd) EtcdClientCreated(client *EtcdClient) {
 		if err != nil {
 			panic(err)
 		}
-		for {
-			response, err := p.getProxyUrls(client, p.keyPrefix)
+
+		var nextRevision int64
+		for p.closeCtx.Err() == nil {
+			response, err := p.getProxyUrls(p.closeCtx, client, p.keyPrefix)
 			if err != nil {
-				if err == context.DeadlineExceeded {
+				if errors.Is(err, context.Canceled) {
+					return
+				} else if errors.Is(err, context.DeadlineExceeded) {
 					log.Printf("Timeout getting initial list of proxy URLs, retry in %s", backoff.NextWait())
 				} else {
 					log.Printf("Could not get initial list of proxy URLs, retry in %s: %s", backoff.NextWait(), err)
 				}
 
-				backoff.Wait(context.Background())
+				backoff.Wait(p.closeCtx)
 				continue
 			}
 
 			for _, ev := range response.Kvs {
 				p.EtcdKeyUpdated(client, string(ev.Key), ev.Value)
 			}
-			return
+			nextRevision = response.Header.Revision + 1
+			break
+		}
+
+		for p.closeCtx.Err() == nil {
+			var err error
+			if nextRevision, err = client.Watch(p.closeCtx, p.keyPrefix, nextRevision, p, clientv3.WithPrefix()); err != nil {
+				log.Printf("Error processing watch for %s: %s", p.keyPrefix, err)
+			}
 		}
 	}()
 }
@@ -125,8 +144,8 @@ func (p *proxyConfigEtcd) EtcdClientCreated(client *EtcdClient) {
 func (p *proxyConfigEtcd) EtcdWatchCreated(client *EtcdClient, key string) {
 }
 
-func (p *proxyConfigEtcd) getProxyUrls(client *EtcdClient, keyPrefix string) (*clientv3.GetResponse, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+func (p *proxyConfigEtcd) getProxyUrls(ctx context.Context, client *EtcdClient, keyPrefix string) (*clientv3.GetResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, time.Second)
 	defer cancel()
 
 	return client.Get(ctx, keyPrefix, clientv3.WithPrefix())


### PR DESCRIPTION
- Properly cancel watch if object is closed.
- Retry watch if interupted.
- Pass revision to watch to not miss changes.