### PR TITLE
Don't keep expiration timestamp in each session.

### DIFF
--- a/clientsession.go
+++ b/clientsession.go
@@ -36,9 +36,6 @@ import (
 )
 
 var (
-	// Sessions expire 30 seconds after the connection closed.
-	sessionExpireDuration = 30 * time.Second
-
 	// Warn if a session has 32 or more pending messages.
 	warnPendingMessagesCount = 32
 
@@ -67,8 +64,6 @@ type ClientSession struct {
 	backend          *Backend
 	backendUrl       string
 	parsedBackendUrl *url.URL
-
-	expires time.Time
 
 	mu sync.Mutex
 
@@ -311,21 +306,6 @@ func (s *ClientSession) UserId() string {
 
 func (s *ClientSession) UserData() *json.RawMessage {
 	return s.userData
-}
-
-func (s *ClientSession) StartExpire() {
-	// The hub mutex must be held when calling this method.
-	s.expires = time.Now().Add(sessionExpireDuration)
-	s.hub.expiredSessions[s] = true
-}
-
-func (s *ClientSession) StopExpire() {
-	// The hub mutex must be held when calling this method.
-	delete(s.hub.expiredSessions, s)
-}
-
-func (s *ClientSession) IsExpired(now time.Time) bool {
-	return now.After(s.expires)
 }
 
 func (s *ClientSession) SetRoom(room *Room) {

--- a/roomsessions_test.go
+++ b/roomsessions_test.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"net/url"
 	"testing"
-	"time"
 )
 
 type DummySession struct {
@@ -78,10 +77,6 @@ func (s *DummySession) GetRoom() *Room {
 
 func (s *DummySession) LeaveRoom(notify bool) *Room {
 	return nil
-}
-
-func (s *DummySession) IsExpired(now time.Time) bool {
-	return false
 }
 
 func (s *DummySession) Close() {

--- a/session.go
+++ b/session.go
@@ -69,7 +69,6 @@ type Session interface {
 	GetRoom() *Room
 	LeaveRoom(notify bool) *Room
 
-	IsExpired(now time.Time) bool
 	Close()
 
 	HasPermission(permission Permission) bool

--- a/virtualsession.go
+++ b/virtualsession.go
@@ -27,7 +27,6 @@ import (
 	"log"
 	"net/url"
 	"sync/atomic"
-	"time"
 )
 
 const (
@@ -158,10 +157,6 @@ func (s *VirtualSession) LeaveRoom(notify bool) *Room {
 	s.SetRoom(nil)
 	room.RemoveSession(s)
 	return room
-}
-
-func (s *VirtualSession) IsExpired(now time.Time) bool {
-	return false
 }
 
 func (s *VirtualSession) Close() {


### PR DESCRIPTION
Reduces memory size per session and make hub lock usage consistent.