### PR TITLE
Relax "MessageClientMessageData" validation.

### DIFF
--- a/api_signaling.go
+++ b/api_signaling.go
@@ -566,7 +566,7 @@ type MessageClientMessageData struct {
 }
 
 func (m *MessageClientMessageData) CheckValid() error {
-	if !IsValidStreamType(m.RoomType) {
+	if m.RoomType != "" && !IsValidStreamType(m.RoomType) {
 		return fmt.Errorf("invalid room type: %s", m.RoomType)
 	}
 	return nil


### PR DESCRIPTION
Allow empty `roomType` values.

Tentative fix for https://github.com/nextcloud/spreed/issues/12252 (cc @danxuliu).