### PR TITLE
make: Don't update CLI tools before installing.

### DIFF
--- a/.github/workflows/tarball.yml
+++ b/.github/workflows/tarball.yml
@@ -77,15 +77,12 @@ jobs:
         [ -d "tmp/vendor" ] || exit 1
 
     - name: Build
-      env:
-        GOPROXY: off
       run: |
         echo "Building with $(nproc) threads"
         make -C tmp build -j$(nproc)
 
     - name: Run tests
       env:
-        GOPROXY: off
         USE_DB_IP_GEOIP_DATABASE: "1"
       run: |
         make -C tmp test TIMEOUT=120s

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,6 @@ build: server proxy
 vendor: go.mod go.sum common
 	set -e ;\
 	rm -rf $(VENDORDIR)
-	$(GO) mod tidy; \
 	$(GO) mod vendor
 
 tarball: vendor

--- a/Makefile
+++ b/Makefile
@@ -70,14 +70,12 @@ hook:
 	[ ! -d "$(CURDIR)/.git/hooks" ] || ln -sf "$(CURDIR)/scripts/pre-commit.hook" "$(CURDIR)/.git/hooks/pre-commit"
 
 $(GOPATHBIN)/easyjson: go.mod go.sum
-	[ "$(GOPROXY)" = "off" ] || $(GO) get -d github.com/mailru/easyjson/...
 	$(GO) install github.com/mailru/easyjson/...
 
 $(GOPATHBIN)/protoc-gen-go: go.mod go.sum
 	$(GO) install google.golang.org/protobuf/cmd/protoc-gen-go
 
 $(GOPATHBIN)/protoc-gen-go-grpc: go.mod go.sum
-	[ "$(GOPROXY)" = "off" ] || $(GO) get -d google.golang.org/grpc/cmd/protoc-gen-go-grpc
 	$(GO) install google.golang.org/grpc/cmd/protoc-gen-go-grpc
 
 continentmap.go:

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /workdir
 COPY . .
 RUN touch /.dockerenv && \
     apk add --no-cache bash git build-base protobuf && \
-    if [ -d "vendor" ]; then GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOPROXY=off make proxy; else \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} make proxy; fi
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} make proxy
 
 FROM alpine:3
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -7,8 +7,7 @@ WORKDIR /workdir
 COPY . .
 RUN touch /.dockerenv && \
     apk add --no-cache bash git build-base protobuf && \
-    if [ -d "vendor" ]; then GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOPROXY=off make server; else \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} make server; fi
+    GOOS=${TARGETOS} GOARCH=${TARGETARCH} make server
 
 FROM alpine:3
 


### PR DESCRIPTION
This makes sure the go.mod / go.sum files are not updated when generating the "vendor" folder (which will generate common files and thus might update the CLI tools). Mismatching "vendor" and "go.*" files will break building.