### PR TITLE
Add feature id for supporting codec parameters in offer.

### DIFF
--- a/api_signaling.go
+++ b/api_signaling.go
@@ -532,6 +532,7 @@ const (
 	ServerFeatureFederation            = "federation"
 	ServerFeatureRecipientCall         = "recipient-call"
 	ServerFeatureJoinFeatures          = "join-features"
+	ServerFeatureOfferCodecs           = "offer-codecs"
 
 	// Features to send to internal clients only.
 	ServerFeatureInternalVirtualSessions = "virtual-sessions"
@@ -553,6 +554,7 @@ var (
 		ServerFeatureFederation,
 		ServerFeatureRecipientCall,
 		ServerFeatureJoinFeatures,
+		ServerFeatureOfferCodecs,
 	}
 	DefaultFeaturesInternal = []string{
 		ServerFeatureInternalVirtualSessions,
@@ -565,6 +567,7 @@ var (
 		ServerFeatureFederation,
 		ServerFeatureRecipientCall,
 		ServerFeatureJoinFeatures,
+		ServerFeatureOfferCodecs,
 	}
 	DefaultWelcomeFeatures = []string{
 		ServerFeatureAudioVideoPermissions,
@@ -578,6 +581,7 @@ var (
 		ServerFeatureFederation,
 		ServerFeatureRecipientCall,
 		ServerFeatureJoinFeatures,
+		ServerFeatureOfferCodecs,
 	}
 )
 

--- a/docs/standalone-signaling-api-v1.md
+++ b/docs/standalone-signaling-api-v1.md
@@ -1027,6 +1027,8 @@ separated list in order of preference.
 - `h264profile`: H.264-specific profile to prefer, e.g. `42e01f` for
 `profile-level-id=42e01f`.
 
+Codec parameters (`audiocodec`, `videocodec`, `vp9profile` and `h264profile`)
+can be provided if the server supports the `offer-codecs` feature id.
 
 Message format (Server -> Client, send answer):
 


### PR DESCRIPTION
This can be used by clients to check if the server supports #853