### PR TITLE
nats: Reconnect client indefinitely.

### DIFF
--- a/async_events_test.go
+++ b/async_events_test.go
@@ -50,8 +50,8 @@ func getAsyncEventsForTest(t *testing.T) AsyncEvents {
 }
 
 func getRealAsyncEventsForTest(t *testing.T) AsyncEvents {
-	url := startLocalNatsServer(t)
-	events, err := NewAsyncEvents(url)
+	server, _ := startLocalNatsServer(t)
+	events, err := NewAsyncEvents(server.ClientURL())
 	if err != nil {
 		require.NoError(t, err)
 	}

--- a/backend_server_test.go
+++ b/backend_server_test.go
@@ -137,7 +137,7 @@ func CreateBackendServerWithClusteringForTestFromConfig(t *testing.T, config1 *g
 		server2.Close()
 	})
 
-	nats := startLocalNatsServer(t)
+	nats, _ := startLocalNatsServer(t)
 	grpcServer1, addr1 := NewGrpcServerForTest(t)
 	grpcServer2, addr2 := NewGrpcServerForTest(t)
 
@@ -156,7 +156,7 @@ func CreateBackendServerWithClusteringForTestFromConfig(t *testing.T, config1 *g
 	config1.AddOption("clients", "internalsecret", string(testInternalSecret))
 	config1.AddOption("geoip", "url", "none")
 
-	events1, err := NewAsyncEvents(nats)
+	events1, err := NewAsyncEvents(nats.ClientURL())
 	require.NoError(err)
 	t.Cleanup(func() {
 		events1.Close()
@@ -179,7 +179,7 @@ func CreateBackendServerWithClusteringForTestFromConfig(t *testing.T, config1 *g
 	config2.AddOption("sessions", "blockkey", "09876543210987654321098765432109")
 	config2.AddOption("clients", "internalsecret", string(testInternalSecret))
 	config2.AddOption("geoip", "url", "none")
-	events2, err := NewAsyncEvents(nats)
+	events2, err := NewAsyncEvents(nats.ClientURL())
 	require.NoError(err)
 	t.Cleanup(func() {
 		events2.Close()

--- a/hub_test.go
+++ b/hub_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/nats-io/nats-server/v2/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -190,10 +191,10 @@ func CreateClusteredHubsForTestWithConfig(t *testing.T, getConfigFunc func(*http
 		server2.Close()
 	})
 
-	nats1 := startLocalNatsServer(t)
-	var nats2 string
+	nats1, _ := startLocalNatsServer(t)
+	var nats2 *server.Server
 	if strings.Contains(t.Name(), "Federation") {
-		nats2 = startLocalNatsServer(t)
+		nats2, _ = startLocalNatsServer(t)
 	} else {
 		nats2 = nats1
 	}
@@ -205,7 +206,7 @@ func CreateClusteredHubsForTestWithConfig(t *testing.T, getConfigFunc func(*http
 		addr1, addr2 = addr2, addr1
 	}
 
-	events1, err := NewAsyncEvents(nats1)
+	events1, err := NewAsyncEvents(nats1.ClientURL())
 	require.NoError(err)
 	t.Cleanup(func() {
 		events1.Close()
@@ -217,7 +218,7 @@ func CreateClusteredHubsForTestWithConfig(t *testing.T, getConfigFunc func(*http
 	require.NoError(err)
 	b1, err := NewBackendServer(config1, h1, "no-version")
 	require.NoError(err)
-	events2, err := NewAsyncEvents(nats2)
+	events2, err := NewAsyncEvents(nats2.ClientURL())
 	require.NoError(err)
 	t.Cleanup(func() {
 		events2.Close()


### PR DESCRIPTION
If the NATS server is offline for too long, the client will stay disconnected otherwise.