### PR TITLE
fix: must match format 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/strukturag/nextcloud-spreed-signaling
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/dlintw/goconf v0.0.0-20120228082610-dcc070983490


### PR DESCRIPTION
```
# make client
mkdir -p "/opt/signaling/bin"
/usr/lib/go-1.18/bin/go build  -ldflags '-X main.version=b719a5602a0c191c5bf9c4f36d422cd9f2867fbd' -o /opt/signaling/bin/client ./client/...
go: errors parsing go.mod:
/opt/signaling/go.mod:3: invalid go version '1.22.0': must match format 1.22
make: *** [Makefile:154: /opt/signaling/bin/client] Error 1
```