### PR TITLE
Explicitly set TMPDIR to ensure that it is a path where go-installed utils (pe. easyjson-bootstrap) can be executed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+tmp/
 vendor/
 
 *.pem


### PR DESCRIPTION
Fixes #955