### PR TITLE
Add "/usr/lib64" to systemd ExecPath

### DIFF
--- a/dist/init/systemd/signaling.service
+++ b/dist/init/systemd/signaling.service
@@ -12,7 +12,7 @@ ConfigurationDirectory=signaling
 
 # Hardening - see systemd.exec(5)
 CapabilityBoundingSet=
-ExecPaths=/usr/bin/signaling /usr/lib
+ExecPaths=/usr/bin/signaling /usr/lib /usr/lib64
 LockPersonality=yes
 MemoryDenyWriteExecute=yes
 NoExecPaths=/


### PR DESCRIPTION
Fixes "Permission denied" errors on Fedora / RedHat systems.

Resolves #943