### PR TITLE
Allow to set GOMAXPROCS

### DIFF
--- a/client/main.go
+++ b/client/main.go
@@ -517,9 +517,7 @@ func main() {
 	}
 	cookie := signaling.NewSessionIdCodec([]byte(hashKey), blockBytes)
 
-	cpus := runtime.NumCPU()
-	runtime.GOMAXPROCS(cpus)
-	log.Printf("Using a maximum of %d CPUs", cpus)
+	log.Printf("Using a maximum of %d CPUs", runtime.GOMAXPROCS(0))
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -76,9 +76,7 @@ func main() {
 		log.Fatal("Could not read configuration: ", err)
 	}
 
-	cpus := runtime.NumCPU()
-	runtime.GOMAXPROCS(cpus)
-	log.Printf("Using a maximum of %d CPUs", cpus)
+	log.Printf("Using a maximum of %d CPUs", runtime.GOMAXPROCS(0))
 
 	r := mux.NewRouter()
 

--- a/server/main.go
+++ b/server/main.go
@@ -166,9 +166,7 @@ func main() {
 		log.Fatal("Could not read configuration: ", err)
 	}
 
-	cpus := runtime.NumCPU()
-	runtime.GOMAXPROCS(cpus)
-	log.Printf("Using a maximum of %d CPUs", cpus)
+	log.Printf("Using a maximum of %d CPUs", runtime.GOMAXPROCS(0))
 
 	signaling.RegisterStats()
 


### PR DESCRIPTION
Currently, I cannot override GOMAXPROCS, because it is hardcoded to be as much as CPUs number.
Since Go 1.5 the default value already set as number of CPUs => previous logic applies by default.
Patch allows to set/override default behavior via environment variable.

https://stackoverflow.com/questions/17853831/what-is-the-gomaxprocs-default-value
https://pkg.go.dev/runtime#GOMAXPROCS