### PR TITLE
Fix subscribers not closed when publisher is closed in Janus 1.x

### DIFF
--- a/mcu_janus_subscriber.go
+++ b/mcu_janus_subscriber.go
@@ -47,6 +47,22 @@ func (p *mcuJanusSubscriber) handleEvent(event *janus.EventMsg) {
 		case "destroyed":
 			log.Printf("Subscriber %d: associated room has been destroyed, closing", p.handleId)
 			go p.Close(ctx)
+		case "updated":
+			streams, ok := getPluginValue(event.Plugindata, pluginVideoRoom, "streams").([]interface{})
+			if !ok || streams == nil || len(streams) == 0 {
+				return
+			}
+
+			for _, stream := range streams {
+				if stream, ok := stream.(map[string]interface{}); ok {
+					if (stream["type"] == "audio" || stream["type"] == "video") && stream["active"] != false {
+						return
+					}
+				}
+			}
+
+			log.Printf("Subscriber %d: received updated event with no active media streams, closing", p.handleId)
+			go p.Close(ctx)
 		case "event":
 			// Handle renegotiations, but ignore other events like selected
 			// substream / temporal layer.


### PR DESCRIPTION
In Janus 0.x [when a publisher is closed the subscribers are also automatically closed](https://github.com/meetecho/janus-gateway/blob/v0.15.1/plugins/janus_videoroom.c#L963) (if configured to do so, [which is the default](https://github.com/meetecho/janus-gateway/blob/v0.15.1/plugins/janus_videoroom.c#L980)). However, in Janus 1.x, as a subscriber can be connected to several publishers, [when a publisher is closed its subscribers just receive an `updated` event with the new state of the streams](https://github.com/meetecho/janus-gateway/blob/v1.3.1/src/plugins/janus_videoroom.c#L1044).

As multistream connections are not used yet in Talk it still makes sense to close its subscribers when a publisher is closed, so subscribers are now automatically closed if they receive an `updated` event and all the media streams are inactive (note that [data channels will be always active](https://github.com/meetecho/janus-gateway/blob/e1c41305218ab720bdb31289d467e8d45fc70f72/src/plugins/janus_videoroom.c#L3530)).

Note that, although it should not be received with the current usage of Janus API, [an `updated` event without streams could be received if the subscriber was updated but there were no changes in the streams](https://github.com/meetecho/janus-gateway/blob/e1c41305218ab720bdb31289d467e8d45fc70f72/src/plugins/janus_videoroom.c#L11660-L11665), so in that case the subscriber should not be closed.

## How to test

- Setup the HPB with Janus 1.x
- Create a public conversation in Talk
- Start a call with camera enabled
- In a private window, join the conversation
- Join the call (for simplicity, without microphone nor camera to have just one publisher in the original window and one subscriber in the private window)
- In the original window, open the browser console
- Close the publisher connection with `OCA.Talk.SimpleWebRTC.webrtc.peers[0].end()`

### Result with this pull request

Eventually the subscriber connection will change to _disconnected_ and then _failed_

### Result without this pull request

The subscriber connection is kept as _connected_ with no hint of a problem, even if the video is frozen; `Unsupported videoroom event updated for subscriber ...` will be printed to the signaling logs.
