### PR TITLE
Add jitter to reconnect intervals.

### DIFF
--- a/mcu_janus.go
+++ b/mcu_janus.go
@@ -45,7 +45,7 @@ const (
 	screenPublisherUserId = 2
 
 	initialReconnectInterval = 1 * time.Second
-	maxReconnectInterval     = 32 * time.Second
+	maxReconnectInterval     = 16 * time.Second
 )
 
 var (

--- a/mcu_proxy.go
+++ b/mcu_proxy.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"math/rand/v2"
 	"net"
 	"net/http"
 	"net/url"
@@ -749,7 +750,10 @@ func (c *mcuProxyConnection) scheduleReconnect() {
 	}
 
 	interval := c.reconnectInterval.Load()
-	c.reconnectTimer.Reset(time.Duration(interval))
+	// Prevent all servers from reconnecting at the same time in case of an
+	// interrupted connection to the proxy or a restart.
+	jitter := rand.Int64N(interval) - (interval / 2)
+	c.reconnectTimer.Reset(time.Duration(interval + jitter))
 
 	interval = interval * 2
 	if interval > int64(maxReconnectInterval) {


### PR DESCRIPTION
This prevents all servers from reconnecting at the same time in case of network interruptions or service restarts.