### PR TITLE
dockerfile: create system user (uid <= 999) instead of normal user (uid >= 1000), avoid home directory

### DIFF
--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -12,7 +12,7 @@ RUN touch /.dockerenv && \
 FROM alpine:3
 
 ENV CONFIG=/config/proxy.conf
-RUN adduser -D spreedbackend && \
+RUN adduser -D -S -H spreedbackend && \
     apk add --no-cache bash tzdata ca-certificates su-exec
 
 COPY --from=builder /workdir/bin/proxy /usr/bin/nextcloud-spreed-signaling-proxy

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -12,7 +12,7 @@ RUN touch /.dockerenv && \
 FROM alpine:3
 
 ENV CONFIG=/config/server.conf
-RUN adduser -D spreedbackend && \
+RUN adduser -D -S -H spreedbackend && \
     apk add --no-cache bash tzdata ca-certificates su-exec
 
 COPY --from=builder /workdir/bin/signaling /usr/bin/nextcloud-spreed-signaling


### PR DESCRIPTION
currently the signaling server is run as uid=1000, which may be the occupied by the first non-root normal user on most unix setups, despite not causing permission or privilege issues, (uid is just an icon in docker, privileges are determined by linux CAPs) a user whose uid=1000 could terminate the process of signaling server running in docker

this patch ensures that user `spreedbackend` in the container has a uid <= 999 by specifying `adduser -S` to address the issue mentioned above

this patch also prevent creating of home directory, which is not necessary, for user `spreedbackend` with `adduser -H`