### PR TITLE
CI: Disable "stdversion" check of govet.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,6 +3,9 @@ linters:
   enable:
     - revive
   settings:
+    govet:
+      disable:
+        - stdversion
     revive:
       severity: warning
       rules:


### PR DESCRIPTION
Using "synctest.Wait" is fine as we set GOEXPERIMENT=synctest when running affected code.