### PR TITLE
fix(docs): already_joined error response

### DIFF
--- a/docs/standalone-signaling-api-v1.md
+++ b/docs/standalone-signaling-api-v1.md
@@ -493,9 +493,11 @@ Message format (Server -> Client if already joined before):
         "code": "already_joined",
         "message": "Human readable error message",
         "details": {
-          "roomid": "the-room-id",
-          "properties": {
-            ...additional room properties...
+          "room": {
+            "roomid": "the-room-id",
+            "properties": {
+              ...additional room properties...
+            }
           }
         }
       }


### PR DESCRIPTION
That is the error response I received:

```
{
  "id": "4",
  "type": "error",
  "error": {
    "code": "already_joined"
    "message": "Already joined this room.",
    "details": {
      "room": {
        "roomid": "5tsemb7k",
        "properties": {
          "description": "",
          "lobby-timer": null,
          "listable": 0,
          "active-since": null,
          "lobby-state": 0,
          "type": 2,
          "sip-enabled": 0,
          "name": "Test",
          "read-only": 0
        }
      }
    },
  }
}
```

which differs from the current documentation.