### PR TITLE
Process all NATS messages for same target from single goroutine.

### DIFF
--- a/async_events_nats.go
+++ b/async_events_nats.go
@@ -23,6 +23,7 @@ package signaling
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -59,176 +60,7 @@ func GetSubjectForSessionId(sessionId PublicSessionId, backend *Backend) string 
 	return string("session." + sessionId)
 }
 
-type asyncSubscriberNats struct {
-	key    string
-	client NatsClient
-	logger log.Logger
-
-	receiver     chan *nats.Msg
-	closeChan    chan struct{}
-	subscription NatsSubscription
-
-	processMessage func(*nats.Msg)
-}
-
-func newAsyncSubscriberNats(logger log.Logger, key string, client NatsClient) (*asyncSubscriberNats, error) {
-	receiver := make(chan *nats.Msg, 64)
-	sub, err := client.Subscribe(key, receiver)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &asyncSubscriberNats{
-		key:    key,
-		client: client,
-		logger: logger,
-
-		receiver:     receiver,
-		closeChan:    make(chan struct{}),
-		subscription: sub,
-	}
-	return result, nil
-}
-
-func (s *asyncSubscriberNats) run() {
-	defer func() {
-		if err := s.subscription.Unsubscribe(); err != nil {
-			s.logger.Printf("Error unsubscribing %s: %s", s.key, err)
-		}
-	}()
-
-	for {
-		select {
-		case msg := <-s.receiver:
-			s.processMessage(msg)
-			for count := len(s.receiver); count > 0; count-- {
-				s.processMessage(<-s.receiver)
-			}
-		case <-s.closeChan:
-			return
-		}
-	}
-}
-
-func (s *asyncSubscriberNats) close() {
-	close(s.closeChan)
-}
-
-type asyncBackendRoomSubscriberNats struct {
-	*asyncSubscriberNats
-	asyncBackendRoomSubscriber
-}
-
-func newAsyncBackendRoomSubscriberNats(logger log.Logger, key string, client NatsClient) (*asyncBackendRoomSubscriberNats, error) {
-	sub, err := newAsyncSubscriberNats(logger, key, client)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &asyncBackendRoomSubscriberNats{
-		asyncSubscriberNats: sub,
-	}
-	result.processMessage = result.doProcessMessage
-	go result.run()
-	return result, nil
-}
-
-func (s *asyncBackendRoomSubscriberNats) doProcessMessage(msg *nats.Msg) {
-	var message AsyncMessage
-	if err := s.client.Decode(msg, &message); err != nil {
-		s.logger.Printf("Could not decode NATS message %+v, %s", msg, err)
-		return
-	}
-
-	s.processBackendRoomRequest(&message)
-}
-
-type asyncRoomSubscriberNats struct {
-	asyncRoomSubscriber
-	*asyncSubscriberNats
-}
-
-func newAsyncRoomSubscriberNats(logger log.Logger, key string, client NatsClient) (*asyncRoomSubscriberNats, error) {
-	sub, err := newAsyncSubscriberNats(logger, key, client)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &asyncRoomSubscriberNats{
-		asyncSubscriberNats: sub,
-	}
-	result.processMessage = result.doProcessMessage
-	go result.run()
-	return result, nil
-}
-
-func (s *asyncRoomSubscriberNats) doProcessMessage(msg *nats.Msg) {
-	var message AsyncMessage
-	if err := s.client.Decode(msg, &message); err != nil {
-		s.logger.Printf("Could not decode NATS message %+v, %s", msg, err)
-		return
-	}
-
-	s.processAsyncRoomMessage(&message)
-}
-
-type asyncUserSubscriberNats struct {
-	*asyncSubscriberNats
-	asyncUserSubscriber
-}
-
-func newAsyncUserSubscriberNats(logger log.Logger, key string, client NatsClient) (*asyncUserSubscriberNats, error) {
-	sub, err := newAsyncSubscriberNats(logger, key, client)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &asyncUserSubscriberNats{
-		asyncSubscriberNats: sub,
-	}
-	result.processMessage = result.doProcessMessage
-	go result.run()
-	return result, nil
-}
-
-func (s *asyncUserSubscriberNats) doProcessMessage(msg *nats.Msg) {
-	var message AsyncMessage
-	if err := s.client.Decode(msg, &message); err != nil {
-		s.logger.Printf("Could not decode NATS message %+v, %s", msg, err)
-		return
-	}
-
-	s.processAsyncUserMessage(&message)
-}
-
-type asyncSessionSubscriberNats struct {
-	*asyncSubscriberNats
-	asyncSessionSubscriber
-}
-
-func newAsyncSessionSubscriberNats(logger log.Logger, key string, client NatsClient) (*asyncSessionSubscriberNats, error) {
-	sub, err := newAsyncSubscriberNats(logger, key, client)
-	if err != nil {
-		return nil, err
-	}
-
-	result := &asyncSessionSubscriberNats{
-		asyncSubscriberNats: sub,
-	}
-	result.processMessage = result.doProcessMessage
-	go result.run()
-	return result, nil
-}
-
-func (s *asyncSessionSubscriberNats) doProcessMessage(msg *nats.Msg) {
-	var message AsyncMessage
-	if err := s.client.Decode(msg, &message); err != nil {
-		s.logger.Printf("Could not decode NATS message %+v, %s", msg, err)
-		return
-	}
-
-	s.processAsyncSessionMessage(&message)
-}
+type asyncEventsNatsSubscriptions map[string]map[AsyncEventListener]NatsSubscription
 
 type asyncEventsNats struct {
 	mu     sync.Mutex
@@ -236,13 +68,13 @@ type asyncEventsNats struct {
 	logger log.Logger // +checklocksignore
 
 	// +checklocks:mu
-	backendRoomSubscriptions map[string]*asyncBackendRoomSubscriberNats
+	backendRoomSubscriptions asyncEventsNatsSubscriptions
 	// +checklocks:mu
-	roomSubscriptions map[string]*asyncRoomSubscriberNats
+	roomSubscriptions asyncEventsNatsSubscriptions
 	// +checklocks:mu
-	userSubscriptions map[string]*asyncUserSubscriberNats
+	userSubscriptions asyncEventsNatsSubscriptions
 	// +checklocks:mu
-	sessionSubscriptions map[string]*asyncSessionSubscriberNats
+	sessionSubscriptions asyncEventsNatsSubscriptions
 }
 
 func NewAsyncEventsNats(logger log.Logger, client NatsClient) (AsyncEvents, error) {
@@ -250,10 +82,10 @@ func NewAsyncEventsNats(logger log.Logger, client NatsClient) (AsyncEvents, erro
 		client: client,
 		logger: logger,
 
-		backendRoomSubscriptions: make(map[string]*asyncBackendRoomSubscriberNats),
-		roomSubscriptions:        make(map[string]*asyncRoomSubscriberNats),
-		userSubscriptions:        make(map[string]*asyncUserSubscriberNats),
-		sessionSubscriptions:     make(map[string]*asyncSessionSubscriberNats),
+		backendRoomSubscriptions: make(asyncEventsNatsSubscriptions),
+		roomSubscriptions:        make(asyncEventsNatsSubscriptions),
+		userSubscriptions:        make(asyncEventsNatsSubscriptions),
+		sessionSubscriptions:     make(asyncEventsNatsSubscriptions),
 	}
 	return events, nil
 }
@@ -283,186 +115,153 @@ func (e *asyncEventsNats) GetServerInfoNats() *BackendServerInfoNats {
 	return nats
 }
 
+func closeSubscriptions(logger log.Logger, wg *sync.WaitGroup, subscriptions asyncEventsNatsSubscriptions) {
+	defer wg.Done()
+
+	for subject, subs := range subscriptions {
+		for _, sub := range subs {
+			if err := sub.Unsubscribe(); err != nil && !errors.Is(err, nats.ErrConnectionClosed) {
+				logger.Printf("Error unsubscribing %s: %s", subject, err)
+			}
+		}
+	}
+}
+
 func (e *asyncEventsNats) Close(ctx context.Context) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go func(subscriptions map[string]*asyncBackendRoomSubscriberNats) {
-		defer wg.Done()
-		for _, sub := range subscriptions {
-			sub.close()
-		}
-	}(e.backendRoomSubscriptions)
+	go closeSubscriptions(e.logger, &wg, e.backendRoomSubscriptions)
 	wg.Add(1)
-	go func(subscriptions map[string]*asyncRoomSubscriberNats) {
-		defer wg.Done()
-		for _, sub := range subscriptions {
-			sub.close()
-		}
-	}(e.roomSubscriptions)
+	go closeSubscriptions(e.logger, &wg, e.roomSubscriptions)
 	wg.Add(1)
-	go func(subscriptions map[string]*asyncUserSubscriberNats) {
-		defer wg.Done()
-		for _, sub := range subscriptions {
-			sub.close()
-		}
-	}(e.userSubscriptions)
+	go closeSubscriptions(e.logger, &wg, e.userSubscriptions)
 	wg.Add(1)
-	go func(subscriptions map[string]*asyncSessionSubscriberNats) {
-		defer wg.Done()
-		for _, sub := range subscriptions {
-			sub.close()
-		}
-	}(e.sessionSubscriptions)
+	go closeSubscriptions(e.logger, &wg, e.sessionSubscriptions)
 	// Can't use clear(...) here as the maps are processed asynchronously by the
 	// goroutines above.
-	e.backendRoomSubscriptions = make(map[string]*asyncBackendRoomSubscriberNats)
-	e.roomSubscriptions = make(map[string]*asyncRoomSubscriberNats)
-	e.userSubscriptions = make(map[string]*asyncUserSubscriberNats)
-	e.sessionSubscriptions = make(map[string]*asyncSessionSubscriberNats)
+	e.backendRoomSubscriptions = make(asyncEventsNatsSubscriptions)
+	e.roomSubscriptions = make(asyncEventsNatsSubscriptions)
+	e.userSubscriptions = make(asyncEventsNatsSubscriptions)
+	e.sessionSubscriptions = make(asyncEventsNatsSubscriptions)
 	wg.Wait()
 	return e.client.Close(ctx)
 }
 
-func (e *asyncEventsNats) RegisterBackendRoomListener(roomId string, backend *Backend, listener AsyncBackendRoomEventListener) error {
+// +checklocks:e.mu
+func (e *asyncEventsNats) registerListener(key string, subscriptions asyncEventsNatsSubscriptions, listener AsyncEventListener) error {
+	subs, found := subscriptions[key]
+	if !found {
+		subs = make(map[AsyncEventListener]NatsSubscription)
+		subscriptions[key] = subs
+	} else if _, found := subs[listener]; found {
+		return ErrAlreadyRegistered
+	}
+
+	sub, err := e.client.Subscribe(key, listener.AsyncChannel())
+	if err != nil {
+		return err
+	}
+
+	subs[listener] = sub
+	return nil
+}
+
+// +checklocks:e.mu
+func (e *asyncEventsNats) unregisterListener(key string, subscriptions asyncEventsNatsSubscriptions, listener AsyncEventListener) error {
+	subs, found := subscriptions[key]
+	if !found {
+		return nil
+	}
+
+	sub, found := subs[listener]
+	if !found {
+		return nil
+	}
+
+	delete(subs, listener)
+	if len(subs) == 0 {
+		delete(subscriptions, key)
+	}
+
+	return sub.Unsubscribe()
+}
+
+func (e *asyncEventsNats) RegisterBackendRoomListener(roomId string, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForBackendRoomId(roomId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.backendRoomSubscriptions[key]
-	if !found {
-		var err error
-		if sub, err = newAsyncBackendRoomSubscriberNats(e.logger, key, e.client); err != nil {
-			return err
-		}
 
-		e.backendRoomSubscriptions[key] = sub
-	}
-	sub.addListener(listener)
-	return nil
+	return e.registerListener(key, e.backendRoomSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) UnregisterBackendRoomListener(roomId string, backend *Backend, listener AsyncBackendRoomEventListener) {
+func (e *asyncEventsNats) UnregisterBackendRoomListener(roomId string, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForBackendRoomId(roomId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.backendRoomSubscriptions[key]
-	if !found {
-		return
-	}
 
-	if !sub.removeListener(listener) {
-		delete(e.backendRoomSubscriptions, key)
-		sub.close()
-	}
+	return e.unregisterListener(key, e.backendRoomSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) RegisterRoomListener(roomId string, backend *Backend, listener AsyncRoomEventListener) error {
+func (e *asyncEventsNats) RegisterRoomListener(roomId string, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForRoomId(roomId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.roomSubscriptions[key]
-	if !found {
-		var err error
-		if sub, err = newAsyncRoomSubscriberNats(e.logger, key, e.client); err != nil {
-			return err
-		}
 
-		e.roomSubscriptions[key] = sub
-	}
-	sub.addListener(listener)
-	return nil
+	return e.registerListener(key, e.roomSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) UnregisterRoomListener(roomId string, backend *Backend, listener AsyncRoomEventListener) {
+func (e *asyncEventsNats) UnregisterRoomListener(roomId string, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForRoomId(roomId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.roomSubscriptions[key]
-	if !found {
-		return
-	}
 
-	if !sub.removeListener(listener) {
-		delete(e.roomSubscriptions, key)
-		sub.close()
-	}
+	return e.unregisterListener(key, e.roomSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) RegisterUserListener(roomId string, backend *Backend, listener AsyncUserEventListener) error {
+func (e *asyncEventsNats) RegisterUserListener(roomId string, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForUserId(roomId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.userSubscriptions[key]
-	if !found {
-		var err error
-		if sub, err = newAsyncUserSubscriberNats(e.logger, key, e.client); err != nil {
-			return err
-		}
 
-		e.userSubscriptions[key] = sub
-	}
-	sub.addListener(listener)
-	return nil
+	return e.registerListener(key, e.userSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) UnregisterUserListener(roomId string, backend *Backend, listener AsyncUserEventListener) {
+func (e *asyncEventsNats) UnregisterUserListener(roomId string, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForUserId(roomId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.userSubscriptions[key]
-	if !found {
-		return
-	}
 
-	if !sub.removeListener(listener) {
-		delete(e.userSubscriptions, key)
-		sub.close()
-	}
+	return e.unregisterListener(key, e.userSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) RegisterSessionListener(sessionId PublicSessionId, backend *Backend, listener AsyncSessionEventListener) error {
+func (e *asyncEventsNats) RegisterSessionListener(sessionId PublicSessionId, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForSessionId(sessionId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.sessionSubscriptions[key]
-	if !found {
-		var err error
-		if sub, err = newAsyncSessionSubscriberNats(e.logger, key, e.client); err != nil {
-			return err
-		}
 
-		e.sessionSubscriptions[key] = sub
-	}
-	sub.addListener(listener)
-	return nil
+	return e.registerListener(key, e.sessionSubscriptions, listener)
 }
 
-func (e *asyncEventsNats) UnregisterSessionListener(sessionId PublicSessionId, backend *Backend, listener AsyncSessionEventListener) {
+func (e *asyncEventsNats) UnregisterSessionListener(sessionId PublicSessionId, backend *Backend, listener AsyncEventListener) error {
 	key := GetSubjectForSessionId(sessionId, backend)
 
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	sub, found := e.sessionSubscriptions[key]
-	if !found {
-		return
-	}
 
-	if !sub.removeListener(listener) {
-		delete(e.sessionSubscriptions, key)
-		sub.close()
-	}
+	return e.unregisterListener(key, e.sessionSubscriptions, listener)
 }
 
 func (e *asyncEventsNats) publish(subject string, message *AsyncMessage) error {
-	message.SendTime = time.Now()
+	message.SendTime = time.Now().Truncate(time.Microsecond)
 	return e.client.Publish(subject, message)
 }
 

--- a/clientsession_test.go
+++ b/clientsession_test.go
@@ -216,7 +216,7 @@ func TestFeatureChatRelay(t *testing.T) {
 			require.NoError(err)
 
 			// Simulate request from the backend.
-			room.ProcessBackendRoomRequest(&AsyncMessage{
+			room.processAsyncMessage(&AsyncMessage{
 				Type: "room",
 				Room: &BackendServerRoomRequest{
 					Type: "message",
@@ -413,7 +413,7 @@ func TestFeatureChatRelayFederation(t *testing.T) {
 			require.NoError(err)
 
 			// Simulate request from the backend.
-			room.ProcessBackendRoomRequest(&AsyncMessage{
+			room.processAsyncMessage(&AsyncMessage{
 				Type: "room",
 				Room: &BackendServerRoomRequest{
 					Type: "message",
@@ -513,7 +513,7 @@ func TestPermissionHideDisplayNames(t *testing.T) {
 			require.NoError(err)
 
 			// Simulate request from the backend.
-			room.ProcessBackendRoomRequest(&AsyncMessage{
+			room.processAsyncMessage(&AsyncMessage{
 				Type: "room",
 				Room: &BackendServerRoomRequest{
 					Type: "message",

--- a/hub_test.go
+++ b/hub_test.go
@@ -3361,7 +3361,7 @@ func TestCombineChatRefreshWhileDisconnected(t *testing.T) {
 	require.NoError(json.Unmarshal([]byte(chat_refresh), &data))
 
 	// Simulate requests from the backend.
-	room.ProcessBackendRoomRequest(&AsyncMessage{
+	room.processAsyncMessage(&AsyncMessage{
 		Type: "room",
 		Room: &BackendServerRoomRequest{
 			Type: "message",
@@ -3370,7 +3370,7 @@ func TestCombineChatRefreshWhileDisconnected(t *testing.T) {
 			},
 		},
 	})
-	room.ProcessBackendRoomRequest(&AsyncMessage{
+	room.processAsyncMessage(&AsyncMessage{
 		Type: "room",
 		Room: &BackendServerRoomRequest{
 			Type: "message",

--- a/natsclient.go
+++ b/natsclient.go
@@ -53,8 +53,6 @@ type NatsClient interface {
 
 	Subscribe(subject string, ch chan *nats.Msg) (NatsSubscription, error)
 	Publish(subject string, message any) error
-
-	Decode(msg *nats.Msg, v any) error
 }
 
 // The NATS client doesn't work if a subject contains spaces. As the room id
@@ -156,7 +154,7 @@ func (c *natsClient) Publish(subject string, message any) error {
 	return c.conn.Publish(subject, data)
 }
 
-func (c *natsClient) Decode(msg *nats.Msg, vPtr any) (err error) {
+func NatsDecode(msg *nats.Msg, vPtr any) (err error) {
 	switch arg := vPtr.(type) {
 	case *string:
 		// If they want a string and it is a JSON string, strip quotes

--- a/natsclient_loopback.go
+++ b/natsclient_loopback.go
@@ -192,7 +192,3 @@ func (c *LoopbackNatsClient) Publish(subject string, message any) error {
 	c.wakeup.Signal()
 	return nil
 }
-
-func (c *LoopbackNatsClient) Decode(msg *nats.Msg, v any) error {
-	return json.Unmarshal(msg.Data, v)
-}


### PR DESCRIPTION
This should help for cases where ordering of messages is swapped under load if sent for example to session and room listeners of same session, but the room message is processed first.