### PR TITLE
checklocks: Remove ignore since generics are supported now.

### DIFF
--- a/container/concurrentmap.go
+++ b/container/concurrentmap.go
@@ -28,7 +28,7 @@ import (
 type ConcurrentMap[K comparable, V any] struct {
 	mu sync.RWMutex
 	// +checklocks:mu
-	d map[K]V // +checklocksignore: Not supported yet, see https://github.com/google/gvisor/issues/11671
+	d map[K]V
 }
 
 func (m *ConcurrentMap[K, V]) Set(key K, value V) {

--- a/test/storage.go
+++ b/test/storage.go
@@ -29,7 +29,7 @@ import (
 type Storage[T any] struct {
 	mu sync.Mutex
 	// +checklocks:mu
-	entries map[string]T // +checklocksignore: Not supported yet, see https://github.com/google/gvisor/issues/11671
+	entries map[string]T
 }
 
 func (s *Storage[T]) cleanup(key string) {


### PR DESCRIPTION
Was implemented in https://github.com/google/gvisor/pull/12443