### PR TITLE
Move tools helpers to internal package.

### DIFF
--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -21,7 +21,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package signaling
+package tools
 
 // Import applications that would otherwise not be detected by "go mod vendor".
 import (

--- a/internal/tools/vendor_helper_test.go
+++ b/internal/tools/vendor_helper_test.go
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package signaling
+package tools
 
 // Import modules that would otherwise not be detected by "go mod vendor".
 import (


### PR DESCRIPTION
This should help reducing dependencies when importing from other projects.