### PR TITLE
feat: added github pipeline for janus

### DIFF
--- a/.github/workflows/docker-janus.yml
+++ b/.github/workflows/docker-janus.yml
@@ -14,9 +14,11 @@ on:
 
 permissions:
   contents: read
+  packages: write
 
 env:
   TEST_TAG: strukturag/nextcloud-spreed-signaling:janus-test
+  IMAGE_TAG: ghcr.io/strukturag/nextcloud-spreed-signaling:janus
 
 jobs:
   build:
@@ -25,6 +27,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -32,5 +42,6 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: docker/janus
-          load: true
-          tags: ${{ env.TEST_TAG }}
+          load: ${{ github.event_name == 'pull_request' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ github.event_name == 'pull_request' && env.TEST_TAG || env.IMAGE_TAG }}


### PR DESCRIPTION
Thanks for the hard work! I am using this signaling server for a while now and created this build pipeline, when I started: https://github.com/creyD/janus for just creating a ghcr.io container image to pull in my deployments (as I didn't find it anywhere else prebuilt).

Maybe this is interesting for you, or maybe you have your reasons for not publishing this on your own in the first place. If there is anything to change or test, feel free to ping me.