### PR TITLE
grpc: Fix error code for unknown room session ids.

### DIFF
--- a/server/hub.go
+++ b/server/hub.go
@@ -1681,7 +1681,7 @@ func (h *Hub) processHelloInternal(client ClientWithSession, message *api.Client
 
 func (h *Hub) disconnectByRoomSessionId(ctx context.Context, roomSessionId api.RoomSessionId, backend *talk.Backend) {
 	sessionId, err := h.roomSessions.LookupSessionId(ctx, roomSessionId, "room_session_reconnected")
-	if err == ErrNoSuchRoomSession {
+	if errors.Is(err, ErrNoSuchRoomSession) {
 		return
 	} else if err != nil {
 		h.logger.Printf("Could not get session id for room session %s: %s", roomSessionId, err)

--- a/server/hub_test.go
+++ b/server/hub_test.go
@@ -58,6 +58,7 @@ import (
 	eventstest "github.com/strukturag/nextcloud-spreed-signaling/v2/async/events/test"
 	"github.com/strukturag/nextcloud-spreed-signaling/v2/container"
 	"github.com/strukturag/nextcloud-spreed-signaling/v2/geoip"
+	"github.com/strukturag/nextcloud-spreed-signaling/v2/grpc"
 	grpctest "github.com/strukturag/nextcloud-spreed-signaling/v2/grpc/test"
 	"github.com/strukturag/nextcloud-spreed-signaling/v2/internal"
 	"github.com/strukturag/nextcloud-spreed-signaling/v2/log"
@@ -5306,4 +5307,26 @@ func TestHubGetPublisherIdForSessionId(t *testing.T) {
 	}))
 
 	<-done
+}
+
+func TestClusteredUnknownRoomSessionIdNotFound(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	hub1, hub2, _, _ := CreateClusteredHubsForTest(t)
+
+	ctx, cancel := context.WithTimeout(t.Context(), testTimeout)
+	defer cancel()
+
+	for _, grpcClient := range hub1.rpcClients.GetClients() {
+		id, err := grpcClient.LookupSessionId(ctx, "unknown-room-sessionid", "")
+		assert.Empty(id)
+		assert.ErrorIs(err, grpc.ErrNoSuchRoomSession)
+	}
+
+	for _, grpcClient := range hub2.rpcClients.GetClients() {
+		id, err := grpcClient.LookupSessionId(ctx, "unknown-room-sessionid", "")
+		assert.Empty(id)
+		assert.ErrorIs(err, grpc.ErrNoSuchRoomSession)
+	}
 }

--- a/server/roomsessions.go
+++ b/server/roomsessions.go
@@ -23,13 +23,13 @@ package server
 
 import (
 	"context"
-	"errors"
 
 	"github.com/strukturag/nextcloud-spreed-signaling/v2/api"
+	"github.com/strukturag/nextcloud-spreed-signaling/v2/grpc"
 )
 
 var (
-	ErrNoSuchRoomSession = errors.New("unknown room session id")
+	ErrNoSuchRoomSession = grpc.ErrNoSuchRoomSession
 )
 
 type RoomSessions interface {


### PR DESCRIPTION
Such requests should return code NotFound but due to different error variables, an error with code Unknown was returned before.

Reported in #1261