### PR TITLE
Fix deadlock when a remote (cross-server) subscriber re-attaches its handle

### DIFF
--- a/sfu/janus/janus.go
+++ b/sfu/janus/janus.go
@@ -956,6 +956,25 @@ func (m *janusSFU) getOrCreateSubscriberHandle(ctx context.Context, publisher ap
 	return handle, pub, nil
 }
 
+// getOrCreateRemoteSubscriberHandle attaches a fresh subscriber handle for a
+// remote publisher. Unlike getOrCreateSubscriberHandle it must not go through
+// getPublisher: remote publishers are tracked only in m.remotePublishers, so a
+// lookup in m.publishers would block until the context deadline.
+func (m *janusSFU) getOrCreateRemoteSubscriberHandle(ctx context.Context, pub *janusRemotePublisher) (*janus.Handle, error) {
+	session := m.session
+	if session == nil {
+		return nil, sfu.ErrNotConnected
+	}
+
+	handle, err := session.Attach(ctx, pluginVideoRoom)
+	if err != nil {
+		return nil, err
+	}
+
+	m.logger.Printf("Attached remote subscriber to room %d of publisher %s on handle %d", pub.roomId, pub.id, handle.Id)
+	return handle, nil
+}
+
 func (m *janusSFU) NewSubscriber(ctx context.Context, listener sfu.Listener, publisher api.PublicSessionId, streamType sfu.StreamType, initiator sfu.Initiator) (sfu.Subscriber, error) {
 	if _, found := streamTypeUserIds[streamType]; !found {
 		return nil, fmt.Errorf("unsupported stream type %s", streamType)
@@ -1161,6 +1180,7 @@ func (m *janusSFU) NewRemoteSubscriber(ctx context.Context, listener sfu.Listene
 	client.janusClient.handleConnected = client.handleConnected
 	client.janusClient.handleSlowLink = client.handleSlowLink
 	client.janusClient.handleMedia = client.handleMedia
+	client.attachHandle = client.attachRemoteHandle
 	m.registerClient(client)
 	go client.run(handle, client.closeChan)
 	m.stats.IncSubscriber(publisher.StreamType())

--- a/sfu/janus/janus_test.go
+++ b/sfu/janus/janus_test.go
@@ -1731,3 +1731,160 @@ func Test_SubscriberUpdateOffer(t *testing.T) {
 		assert.NoError(ctx.Err())
 	}
 }
+
+func newRemotePublisherHandlers(assert *assert.Assertions) map[string]janustest.JanusHandler {
+	return map[string]janustest.JanusHandler{
+		"add_remote_publisher": func(room *janustest.JanusRoom, body, jsep api.StringMap) (any, *janus.ErrorMsg) {
+			assert.EqualValues(1, room.Id())
+			return &janus.SuccessMsg{
+				PluginData: janus.PluginData{
+					Plugin: pluginVideoRoom,
+					Data: api.StringMap{
+						"id":        12345,
+						"port":      10000,
+						"rtcp_port": 10001,
+					},
+				},
+			}, nil
+		},
+		"remove_remote_publisher": func(room *janustest.JanusRoom, body, jsep api.StringMap) (any, *janus.ErrorMsg) {
+			assert.EqualValues(1, room.Id())
+			return &janus.SuccessMsg{
+				PluginData: janus.PluginData{
+					Plugin: pluginVideoRoom,
+					Data:   api.StringMap{},
+				},
+			}, nil
+		},
+	}
+}
+
+// A remote subscriber that receives JANUS_VIDEOROOM_ERROR_ALREADY_JOINED on
+// joining must attach its new handle from the remote publisher instead of
+// blocking in "getPublisher" (remote publishers only exist in
+// "remotePublishers") until the timeout closes the subscriber.
+func Test_JanusRemoteSubscriberAlreadyJoined(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	stats := &mockJanusStats{}
+
+	t.Cleanup(func() {
+		if !t.Failed() {
+			assert.True(stats.called.Load(), "stats were not called")
+			assert.Equal(0, stats.Value("video"))
+		}
+	})
+
+	mcu, gateway := newMcuJanusForTesting(t)
+	mcu.SetStats(stats)
+	gateway.RegisterHandlers(newRemotePublisherHandlers(assert))
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	listener1 := &TestMcuListener{
+		id: "publisher-id",
+	}
+
+	controller := &TestMcuController{
+		id: listener1.id,
+	}
+
+	pub, err := mcu.NewRemotePublisher(ctx, listener1, controller, sfu.StreamTypeVideo)
+	require.NoError(err)
+	defer pub.Close(context.Background())
+
+	listener2 := &TestMcuListener{
+		id: "subscriber-id",
+	}
+
+	sub, err := mcu.NewRemoteSubscriber(ctx, listener2, pub)
+	require.NoError(err)
+	defer sub.Close(context.Background())
+
+	// Without the fix, the re-join after ALREADY_JOINED blocks in
+	// "getPublisher" until this timeout and the subscriber is closed.
+	oldTimeout := mcu.Settings().Timeout()
+	defer mcu.Settings().SetTimeout(oldTimeout)
+	mcu.Settings().SetTimeout(500 * time.Millisecond)
+
+	msgData := &api.MessageClientMessageData{
+		Type:     "requestoffer",
+		RoomType: "video",
+	}
+	require.NoError(msgData.CheckValid())
+	payload, err := json.Marshal(msgData)
+	require.NoError(err)
+	msg := &api.MessageClientMessage{
+		Recipient: api.MessageClientMessageRecipient{
+			Type:      "session",
+			SessionId: listener1.id,
+		},
+		Data: payload,
+	}
+
+	// The mock gateway returns ALREADY_JOINED for the first subscriber
+	// "join" (test name contains "AlreadyJoined"), exercising the
+	// re-attach path of the remote subscriber.
+	ch := make(chan struct{})
+	sub.SendMessage(ctx, msg, msgData, func(err error, sm api.StringMap) {
+		defer close(ch)
+
+		assert.NoError(err)
+		assert.Equal(mock.MockSdpOfferAudioOnly, sm["sdp"])
+	})
+	<-ch
+
+	assert.False(listener2.closed.Load())
+}
+
+// A reconnect of a remote subscriber must attach its new handle from the
+// remote publisher instead of blocking in "getPublisher" until the timeout.
+func Test_JanusRemoteSubscriberReconnect(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+
+	mcu, gateway := newMcuJanusForTesting(t)
+	gateway.RegisterHandlers(newRemotePublisherHandlers(assert))
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	listener1 := &TestMcuListener{
+		id: "publisher-id",
+	}
+
+	controller := &TestMcuController{
+		id: listener1.id,
+	}
+
+	pub, err := mcu.NewRemotePublisher(ctx, listener1, controller, sfu.StreamTypeVideo)
+	require.NoError(err)
+	defer pub.Close(context.Background())
+
+	listener2 := &TestMcuListener{
+		id: "subscriber-id",
+	}
+
+	sub, err := mcu.NewRemoteSubscriber(ctx, listener2, pub)
+	require.NoError(err)
+	defer sub.Close(context.Background())
+
+	subscriber, ok := sub.(*janusRemoteSubscriber)
+	require.True(ok)
+
+	// Without the fix, reconnecting blocks in "getPublisher" until this
+	// timeout and then closes the subscriber.
+	oldTimeout := mcu.Settings().Timeout()
+	defer mcu.Settings().SetTimeout(oldTimeout)
+	mcu.Settings().SetTimeout(500 * time.Millisecond)
+
+	oldHandle := subscriber.Handle()
+	subscriber.NotifyReconnected()
+
+	assert.NotEqual(oldHandle, subscriber.Handle())
+	assert.False(listener2.closed.Load())
+}

--- a/sfu/janus/remote_subscriber.go
+++ b/sfu/janus/remote_subscriber.go
@@ -26,6 +26,7 @@ import (
 	"strconv"
 	"sync/atomic"
 
+	"github.com/strukturag/nextcloud-spreed-signaling/v2/sfu"
 	"github.com/strukturag/nextcloud-spreed-signaling/v2/sfu/janus/janus"
 )
 
@@ -86,10 +87,30 @@ func (p *janusRemoteSubscriber) handleMedia(event *janus.MediaMsg) {
 	// Only triggered for publishers
 }
 
+// attachRemoteHandle attaches a fresh subscriber handle for the remote
+// publisher of this subscriber. It is installed as janusSubscriber.attachHandle
+// (used by the inherited joinRoom re-join path) and is also called directly
+// from NotifyReconnected, so neither goes through getOrCreateSubscriberHandle,
+// whose getPublisher only knows local publishers and would block until the
+// context deadline.
+func (p *janusRemoteSubscriber) attachRemoteHandle(ctx context.Context) (*janus.Handle, uint64, error) {
+	pub := p.remote.Load()
+	if pub == nil {
+		return nil, 0, sfu.ErrNotConnected
+	}
+
+	handle, err := p.mcu.getOrCreateRemoteSubscriberHandle(ctx, pub)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return handle, pub.roomId, nil
+}
+
 func (p *janusRemoteSubscriber) NotifyReconnected() {
 	ctx, cancel := context.WithTimeout(context.Background(), p.mcu.settings.Timeout())
 	defer cancel()
-	handle, pub, err := p.mcu.getOrCreateSubscriberHandle(ctx, p.publisher, p.streamType)
+	handle, roomId, err := p.attachRemoteHandle(ctx)
 	if err != nil {
 		// TODO(jojo): Retry?
 		p.logger.Printf("Could not reconnect remote subscriber for publisher %s: %s", p.publisher, err)
@@ -103,7 +124,7 @@ func (p *janusRemoteSubscriber) NotifyReconnected() {
 		}
 	}
 	p.handleId.Store(handle.Id)
-	p.roomId = pub.roomId
+	p.roomId = roomId
 	p.sid = strconv.FormatUint(handle.Id, 10)
 	p.listener.SubscriberSidUpdated(p)
 	p.logger.Printf("Subscriber %d for publisher %s reconnected on handle %d", p.id, p.publisher, p.handleId.Load())

--- a/sfu/janus/subscriber.go
+++ b/sfu/janus/subscriber.go
@@ -36,6 +36,15 @@ type janusSubscriber struct {
 	janusClient
 
 	publisher api.PublicSessionId
+
+	// attachHandle, when non-nil, replaces the default local-publisher lookup
+	// (getOrCreateSubscriberHandle) when a fresh subscriber handle has to be
+	// attached during a re-join (JANUS_VIDEOROOM_ERROR_ALREADY_JOINED).
+	// Remote subscribers set it: their publisher exists only in
+	// janusSFU.remotePublishers, never in janusSFU.publishers, so getPublisher
+	// would block until the context deadline and tear down the call.
+	// Returns the new handle and the room id to (re-)join.
+	attachHandle func(ctx context.Context) (*janus.Handle, uint64, error)
 }
 
 func (p *janusSubscriber) JanusHandle() *janus.Handle {
@@ -210,8 +219,18 @@ retry:
 			p.closeClient(ctx)
 			p.mu.Unlock()
 
-			var pub *janusPublisher
-			handle, pub, err = p.mcu.getOrCreateSubscriberHandle(ctx, p.publisher, p.streamType)
+			var roomId uint64
+			if p.attachHandle != nil {
+				// Remote subscriber: attach a fresh handle directly, the
+				// publisher will never appear in m.publishers.
+				handle, roomId, err = p.attachHandle(ctx)
+			} else {
+				var pub *janusPublisher
+				handle, pub, err = p.mcu.getOrCreateSubscriberHandle(ctx, p.publisher, p.streamType)
+				if err == nil {
+					roomId = pub.roomId
+				}
+			}
 			if err != nil {
 				// Reconnection didn't work, need to unregister/remove subscriber
 				// so a new object will be created if the request is retried.
@@ -227,7 +246,7 @@ retry:
 				}
 			}
 			p.handleId.Store(handle.Id)
-			p.roomId = pub.roomId
+			p.roomId = roomId
 			p.sid = strconv.FormatUint(handle.Id, 10)
 			p.listener.SubscriberSidUpdated(p)
 			p.closeChan = make(chan struct{}, 1)

--- a/sfu/janus/test/janus.go
+++ b/sfu/janus/test/janus.go
@@ -410,6 +410,12 @@ func (g *JanusGateway) processMessage(session *janus.Session, handle *JanusHandl
 							})
 						}
 					}
+				case "add_remote_publisher":
+					// The remote publisher feeds the room, so subscribers can
+					// join it like a room with a locally publishing handle.
+					if room.publisher.CompareAndSwap(nil, handle) {
+						handle.sdp.Store(mock.MockSdpOfferAudioOnly)
+					}
 				}
 			}
 			return result


### PR DESCRIPTION
### Problem

A **remote subscriber** — one whose publisher lives on another signaling server
(the remote-streams SFU path) — deadlocks when it has to re-attach its Janus
handle, either on `JANUS_VIDEOROOM_ERROR_ALREADY_JOINED` during a re-join or
from `NotifyReconnected`. Both paths call `getOrCreateSubscriberHandle` →
`getPublisher`, which resolves only **local** publishers from `m.publishers` and
blocks on a condition variable until the request context deadline. A remote
publisher lives only in `m.remotePublishers`, so the lookup can never succeed:
the subscriber stalls for the full MCU timeout and is torn down with
`context deadline exceeded`, dropping the call. Every re-attach of a remote
subscriber hits this; subscribers are remote whenever publisher and subscriber
are placed on different proxies (e.g. GeoIP-based placement across regions).

Details in #1274.

### Fix

`janusSubscriber` gets an optional `attachHandle` hook. When set, the
`ALREADY_JOINED` re-join path uses it instead of `getOrCreateSubscriberHandle`.
Remote subscribers install `attachRemoteHandle`, which attaches a fresh handle
directly from the already-known `*janusRemotePublisher` via a new
`getOrCreateRemoteSubscriberHandle` — never touching `getPublisher`.
`NotifyReconnected` uses the same helper. Local subscribers are completely
unchanged (the hook is nil for them).

The hook follows the function-field dispatch `janusClient` already uses
(`handleEvent`, `handleHangup`, …) and is assigned in `NewRemoteSubscriber`.
This mirrors what `NewRemoteSubscriber` already does for the **initial** attach.

### Testing

- `go build ./...`, `go vet ./sfu/janus/...` and `go test ./sfu/janus/...` all
  pass on `master` + this change.
- Added `Test_JanusRemoteSubscriberAlreadyJoined` and
  `Test_JanusRemoteSubscriberReconnect`, which **fail on current master** (the
  subscriber blocks in `getPublisher` until the MCU timeout and is closed) and
  **pass with this change**. The mock gateway needed a small extension so a room
  fed via `add_remote_publisher` is joinable by subscribers (sets
  `room.publisher` and an offer SDP).
- Also verified end-to-end on a 3-proxy deployment with GeoIP placement across
  regions: before, a cross-region subscriber reliably logged
  `context deadline exceeded` on re-attach and the call dropped; after, the
  re-attach resolves and the `ALREADY_JOINED` re-join completes with zero
  deadline errors.

### Notes

Remote streams is a preview feature (since #708). This change only touches the
remote-subscriber re-attach paths; the local subscriber path is untouched. The
touched files are identical between v2.1.1 and `master`, so this also
backports cleanly to the 2.1.x branch.
