### PR TITLE
Limit how long idle backend connections stay pooled

### DIFF
--- a/pool/http_client_pool.go
+++ b/pool/http_client_pool.go
@@ -27,8 +27,8 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
-	"time"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -91,7 +91,7 @@ type HttpClientPool struct {
 
 // idleConnTimeout limits how long an idle backend connection stays in the pool.
 // It must stay below any realistic backend keep-alive timeout (Apache defaults to
-// 5s, nginx to 75s) so that the client always closes an idle connection before the
+// 300s, nginx to 75s) so that the client always closes an idle connection before the
 // server does. See the comment in NewHttpClientPool.
 const idleConnTimeout = 30 * time.Second
 

--- a/pool/http_client_pool.go
+++ b/pool/http_client_pool.go
@@ -27,6 +27,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"time"
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -88,6 +89,12 @@ type HttpClientPool struct {
 	maxConcurrentRequestsPerHost int // +checklocksignore: Only written to from constructor.
 }
 
+// idleConnTimeout limits how long an idle backend connection stays in the pool.
+// It must stay below any realistic backend keep-alive timeout (Apache defaults to
+// 5s, nginx to 75s) so that the client always closes an idle connection before the
+// server does. See the comment in NewHttpClientPool.
+const idleConnTimeout = 30 * time.Second
+
 func NewHttpClientPool(maxConcurrentRequestsPerHost int, skipVerify bool) (*HttpClientPool, error) {
 	if maxConcurrentRequestsPerHost <= 0 {
 		return nil, errors.New("can't create empty pool")
@@ -100,6 +107,27 @@ func NewHttpClientPool(maxConcurrentRequestsPerHost int, skipVerify bool) (*Http
 		MaxIdleConnsPerHost: maxConcurrentRequestsPerHost,
 		TLSClientConfig:     tlsconfig,
 		Proxy:               http.ProxyFromEnvironment,
+		// Limit how long an idle connection may stay pooled.
+		//
+		// This is NOT the default transport, so IdleConnTimeout defaults to its
+		// zero value, which means "no limit" - idle connections are kept forever.
+		// Backend webservers, however, close idle keep-alive connections after
+		// their own timeout (Apache's KeepAliveTimeout, nginx's
+		// keepalive_timeout, and every load balancer in between). The pool
+		// therefore hands out connections the server is closing, and a request
+		// written into one fails with EOF. Go does not retry a POST once bytes
+		// have been written - it is not replayable without an Idempotency-Key -
+		// so the failure surfaces to the caller.
+		//
+		// In practice this shows up as backend requests intermittently failing
+		// with EOF under otherwise normal conditions; on a room-join validation
+		// it means the participant never actually joins the room while the
+		// caller keeps ringing.
+		//
+		// Keeping this below any realistic backend keep-alive timeout makes the
+		// CLIENT close idle connections first, so it can never pick up one that
+		// the server is concurrently tearing down.
+		IdleConnTimeout: idleConnTimeout,
 	}
 
 	result := &HttpClientPool{

--- a/pool/http_client_pool_test.go
+++ b/pool/http_client_pool_test.go
@@ -65,3 +65,29 @@ func TestHttpClientPool(t *testing.T) {
 	_, _, err = pool.Get(ctx3, u2)
 	assert.ErrorIs(err, context.DeadlineExceeded)
 }
+
+func TestHttpClientPoolIdleConnTimeout(t *testing.T) {
+	// A pooled idle connection must be closed by the CLIENT before the backend
+	// webserver closes it. Otherwise the pool eventually hands out a connection
+	// the server is tearing down, the request written into it fails with EOF,
+	// and Go will not retry a POST (not replayable without an Idempotency-Key),
+	// so the backend request is silently lost.
+	//
+	// This is easy to reintroduce: http.Transport's zero value for
+	// IdleConnTimeout means "no limit" (unlike http.DefaultTransport, which sets
+	// 90s), so simply dropping the field restores the bug while the code still
+	// looks correct.
+	assert := assert.New(t)
+	pool, err := NewHttpClientPool(1, false)
+	require.NoError(t, err)
+
+	assert.NotZero(pool.transport.IdleConnTimeout,
+		"IdleConnTimeout must be set: the zero value means idle connections are "+
+			"pooled forever, so the backend webserver will close them first and "+
+			"requests will intermittently fail with EOF")
+
+	// Apache's default KeepAliveTimeout is 5s and nginx's keepalive_timeout is
+	// 75s; staying well below those keeps the client closing first.
+	assert.Less(pool.transport.IdleConnTimeout, 75*time.Second,
+		"IdleConnTimeout must stay below a realistic backend keep-alive timeout")
+}

--- a/pool/http_client_pool_test.go
+++ b/pool/http_client_pool_test.go
@@ -67,6 +67,8 @@ func TestHttpClientPool(t *testing.T) {
 }
 
 func TestHttpClientPoolIdleConnTimeout(t *testing.T) {
+	t.Parallel()
+
 	// A pooled idle connection must be closed by the CLIENT before the backend
 	// webserver closes it. Otherwise the pool eventually hands out a connection
 	// the server is tearing down, the request written into it fails with EOF,
@@ -86,7 +88,7 @@ func TestHttpClientPoolIdleConnTimeout(t *testing.T) {
 			"pooled forever, so the backend webserver will close them first and "+
 			"requests will intermittently fail with EOF")
 
-	// Apache's default KeepAliveTimeout is 5s and nginx's keepalive_timeout is
+	// Apache's default KeepAliveTimeout is 300s and nginx's keepalive_timeout is
 	// 75s; staying well below those keeps the client closing first.
 	assert.Less(pool.transport.IdleConnTimeout, 75*time.Second,
 		"IdleConnTimeout must stay below a realistic backend keep-alive timeout")


### PR DESCRIPTION
We chased an intermittent "the callee answered but never joined the room, the caller just kept ringing" failure for days before it turned out to be here rather than in the client.

## The bug

`NewHttpClientPool` builds its own `http.Transport`:

```go
transport := &http.Transport{
    MaxIdleConnsPerHost: maxConcurrentRequestsPerHost,
    TLSClientConfig:     tlsconfig,
    Proxy:               http.ProxyFromEnvironment,
}
```

Because this is not `http.DefaultTransport`, `IdleConnTimeout` takes its **zero value, which means no limit** — idle connections are pooled indefinitely. (`http.DefaultTransport` sets 90s, which is why this is easy to miss.)

Backend webservers do not keep them open indefinitely: Apache closes idle keep-alive connections after `KeepAliveTimeout`, nginx after `keepalive_timeout`, and load balancers have their own idle timeouts. So the pool can hand out a connection the server is concurrently tearing down. The request written into it fails with a bare `EOF`, and Go will not retry a `POST` — it is not replayable without an `Idempotency-Key`, and once bytes are on the wire it is not a `nothingWrittenError` either — so the failure surfaces to the caller.

Go does evict a FINd idle connection promptly (`persistConn.readLoop` wakes on EOF and removes it), so this is a race at the instant the server closes rather than a permanently rotten pool. That makes it intermittent, load-dependent, and very hard to attribute — especially if the backend has no access logging, which was our case.

When it lands on a room-join validation, the participant never actually joins the room while the caller keeps ringing. It looks exactly like a client bug.

## The fix

Set `IdleConnTimeout` below any realistic backend keep-alive timeout, so the **client** always closes an idle connection first and can never present one the server is closing. That removes the race rather than narrowing it.

30s is comfortably below common defaults (Apache 5s, nginx 75s) while still giving useful connection reuse. Happy to make it configurable instead if you would prefer that.

## Test

Includes a regression test. It fails if the field is removed (the current behaviour) and fails if it is raised above a realistic backend keep-alive — verified both ways, plus green on revert.

Running in production on a 3-region deployment since 2026-07-13; the intermittent join failures stopped.