### PR TITLE
Ignore stale responses to superseded "join room" requests

### DIFF
--- a/server/clientsession.go
+++ b/server/clientsession.go
@@ -91,6 +91,7 @@ type ClientSession struct {
 	client       ClientWithSession
 	room         atomic.Pointer[Room]
 	roomJoinTime atomic.Int64
+	joinRoomSeq  atomic.Uint64
 	federation   atomic.Pointer[FederationClient]
 
 	roomSessionIdLock sync.RWMutex
@@ -334,6 +335,28 @@ func (s *ClientSession) ParsedUserData() (api.StringMap, error) {
 func (s *ClientSession) SetRoom(room *Room, joinTime time.Time) {
 	s.room.Store(room)
 	s.onRoomSet(room != nil, joinTime)
+}
+
+// NextJoinRoomSeq allocates a new sequence number for a "join room" request
+// and returns it.
+//
+// A session is not necessarily driven by a single goroutine: a client can be
+// replaced through SetClient while a previous "join room" request for the same
+// session is still blocked in its backend round-trip, and remote clients feed
+// messages for a session from their own goroutine. The room request therefore
+// has to be able to tell whether its own result is still the current one by the
+// time the backend answers.
+//
+// Callers capture the value before starting the backend request and compare it
+// against CurrentJoinRoomSeq once it returns; see Hub.processJoinRoom.
+func (s *ClientSession) NextJoinRoomSeq() uint64 {
+	return s.joinRoomSeq.Add(1)
+}
+
+// CurrentJoinRoomSeq returns the sequence number of the most recently started
+// "join room" request for this session.
+func (s *ClientSession) CurrentJoinRoomSeq() uint64 {
+	return s.joinRoomSeq.Load()
 }
 
 func (s *ClientSession) onRoomSet(hasRoom bool, joinTime time.Time) {

--- a/server/hub.go
+++ b/server/hub.go
@@ -1918,6 +1918,12 @@ func (h *Hub) processRoom(sess Session, message *api.ClientMessage) {
 		return
 	}
 
+	// Remember which "join room" request this is. The backend request below can
+	// block for up to the backend timeout, during which the session may be taken
+	// over by a resumed client (or fed by a remote client) that starts a newer
+	// join. See ClientSession.NextJoinRoomSeq.
+	joinSeq := session.NextJoinRoomSeq()
+
 	var room talk.BackendClientResponse
 	var joinRoomTime time.Time
 	if session.ClientType() == api.HelloClientTypeInternal {
@@ -1960,7 +1966,7 @@ func (h *Hub) processRoom(sess Session, message *api.ClientMessage) {
 		}
 	}
 
-	h.processJoinRoom(session, message, &room, joinRoomTime)
+	h.processJoinRoom(session, message, &room, joinRoomTime, joinSeq)
 }
 
 func (h *Hub) publishFederatedSessions() (int, *sync.WaitGroup) {
@@ -2118,12 +2124,24 @@ func (h *Hub) createRoomLocked(id string, properties json.RawMessage, backend *t
 	return room, nil
 }
 
-func (h *Hub) processJoinRoom(session *ClientSession, message *api.ClientMessage, room *talk.BackendClientResponse, joinTime time.Time) {
+func (h *Hub) processJoinRoom(session *ClientSession, message *api.ClientMessage, room *talk.BackendClientResponse, joinTime time.Time, joinSeq uint64) {
 	if room.Type == "error" {
 		session.SendMessage(message.NewErrorServerMessage(room.Error))
 		return
 	} else if room.Type != "room" {
 		session.SendMessage(message.NewErrorServerMessage(RoomJoinFailed))
+		return
+	}
+
+	if current := session.CurrentJoinRoomSeq(); current != joinSeq {
+		// A newer "join room" request was started for this session while the
+		// backend was answering this one, so this response is no longer
+		// current. Continuing would leave the room the session actually joined
+		// and replace it with this stale one, purely because the two backend
+		// round-trips completed out of order. The newer request applies its own
+		// result, so drop this one.
+		h.logger.Printf("Ignoring stale response to join room %s for session %s (request %d, current %d)",
+			room.Room.RoomId, session.PublicId(), joinSeq, current)
 		return
 	}
 

--- a/server/hub_test.go
+++ b/server/hub_test.go
@@ -446,6 +446,10 @@ func processRoomRequest(t *testing.T, w http.ResponseWriter, r *http.Request, re
 	switch request.Room.RoomId {
 	case "test-room-slow":
 		time.Sleep(100 * time.Millisecond)
+	case "test-room-very-slow":
+		// Long enough for a test to resume the session on a new client and
+		// complete another join before this request is answered.
+		time.Sleep(500 * time.Millisecond)
 	case "test-room-takeover-room-session":
 		// Additional checks for testcase "TestClientTakeoverRoomSession"
 		if request.Room.Action == "leave" && request.Room.UserId == "test-userid1" {
@@ -3083,6 +3087,58 @@ func TestJoinRoomSwitchClient(t *testing.T) {
 	// Leave room.
 	roomMsg = MustSucceed2(t, client2.JoinRoom, ctx, "")
 	require.Empty(roomMsg.Room.RoomId)
+}
+
+func TestJoinRoomStaleResponseAfterClientSwitch(t *testing.T) {
+	t.Parallel()
+	require := require.New(t)
+	assert := assert.New(t)
+	hub, _, _, server := CreateHubForTest(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), testTimeout)
+	defer cancel()
+
+	client, hello := NewTestClientWithHello(ctx, t, server, hub, testDefaultUserId)
+
+	// Start a join whose backend request takes a long time to be answered.
+	slowRoomId := "test-room-very-slow"
+	msg := &api.ClientMessage{
+		Id:   "ABCD",
+		Type: "room",
+		Room: &api.RoomClientMessage{
+			RoomId:    slowRoomId,
+			SessionId: api.RoomSessionId(fmt.Sprintf("%s-%s", slowRoomId, hello.Hello.SessionId)),
+		},
+	}
+	require.NoError(client.WriteJSON(msg))
+	// Wait a bit to make sure the request reached the backend before the client
+	// goes away, so the response is still pending while the session continues.
+	time.Sleep(10 * time.Millisecond)
+	client.Close()
+	require.NoError(client.WaitForClientRemoved(ctx))
+
+	// Resume the session on a new client and join a different room. This
+	// finishes while the first join is still waiting for its backend response.
+	client2 := NewTestClient(t, server, hub)
+	defer client2.CloseWithBye()
+	require.NoError(client2.SendHelloResume(hello.Hello.ResumeId))
+	_, ok := client2.RunUntilHello(ctx)
+	require.True(ok)
+
+	roomId := "test-room"
+	roomMsg := MustSucceed2(t, client2.JoinRoom, ctx, roomId)
+	require.Equal(roomId, roomMsg.Room.RoomId)
+	client2.RunUntilJoined(ctx, hello.Hello)
+
+	// Give the pending response to the first join time to arrive and be
+	// processed. It is stale by now and must not be applied.
+	time.Sleep(700 * time.Millisecond)
+
+	session, ok := hub.GetSessionByPublicId(hello.Hello.SessionId).(*ClientSession)
+	require.True(ok, "session should still exist")
+	room := session.GetRoom()
+	require.NotNil(room, "session should still be in a room")
+	assert.Equal(roomId, room.Id(), "the superseded join must not replace the current room")
 }
 
 func TestClientMessageToSessionIdWhileDisconnected(t *testing.T) {


### PR DESCRIPTION
A session can be left in a room it already left, if the backend responses to two
"join room" requests complete out of order.

### How two joins overlap for one session

Messages from a single client are processed one at a time (`Client.processMessages`
reads them from a channel and dispatches them synchronously), so this is not about
a client sending two "room" messages in a row. The overlap comes from the session
outliving the client that started the request:

* `ClientSession.SetClient` replaces the client of an existing session, so a
  resumed client can start a new join while a previous one is still running.
* `remoteGrpcClient` feeds messages for a session from its own goroutine.

`Hub.processRoom` performs the backend request with `session.Context()` and a
timeout of `backendTimeout`, so it keeps running after the client that sent it is
gone. The response can therefore arrive after a newer join for the same session
has already completed.

`processJoinRoom` then applies it regardless: it calls `session.LeaveRoom(true)`
and joins the stale room. The session ends up in the room it left, and the room
session created by the newer join is removed again.

### Change

Each "join room" request takes a sequence number from the session before the
backend request is started (`ClientSession.NextJoinRoomSeq`). `processJoinRoom`
compares it against the current value before touching the session and returns
early if a newer request has been started since. The newer request applies its
own result, so nothing is lost by dropping the superseded one.

The check sits after the existing error handling and before `LeaveRoom`, so a
stale response no longer has any side effect. Two atomic operations on the normal
path, no locking.

### Test

`TestJoinRoomStaleResponseAfterClientSwitch` starts a join whose backend response
is delayed, closes the client, resumes the session on a second client, joins a
different room there, and then checks which room the session is in once the
delayed response has been processed.

It uses a new `test-room-very-slow` case in the test backend (500ms) rather than
the existing `test-room-slow` (100ms), so the resume and the second join have room
to complete without the timing being tight.

Without the change the test fails, and the log shows the stale response being
applied 389ms after the correct one:

```
joined room test-room
joined room test-room-very-slow      <- stale response
Removed room session test-room-...
```

### Checks

`go build ./...`, `go vet ./server/`, `gofmt -l server/` are clean, and
`go test ./server/` passes with and without `-race`.

Note that `go test -race -run "TestJoinRoom" ./server/` reports data races in
`api.NewWelcomeServerMessage` (a `slices.Sort` on package-level state, reached
through `NewHub` from several parallel tests). That is present on master without
this change as well, so it is left alone here.
