### PR TITLE
Use single NATS subscription per subject and fan out manually.

### DIFF
--- a/async/events/async_events_nats.go
+++ b/async/events/async_events_nats.go
@@ -61,7 +61,83 @@ func GetSubjectForSessionId(sessionId api.PublicSessionId, backend *talk.Backend
 	return string("session." + sessionId)
 }
 
-type asyncEventsNatsSubscriptions map[string]map[AsyncEventListener]nats.Subscription
+type natsSubscription struct {
+	mu sync.RWMutex
+
+	logger log.Logger        // +checklocksignore
+	sub    nats.Subscription // +checklocksignore
+
+	// +checklocks:mu
+	listeners map[AsyncEventListener]bool
+}
+
+func (s *natsSubscription) sendMessage(msg *nats.Msg) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for listener := range s.listeners {
+		select {
+		case listener.AsyncChannel() <- msg:
+		default:
+			s.logger.Printf("Slow consumer %s, dropping message", msg.Subject)
+		}
+	}
+}
+
+func (s *natsSubscription) empty() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return len(s.listeners) == 0
+}
+
+func (s *natsSubscription) close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.doClose()
+}
+
+// +checklocks:s.mu
+func (s *natsSubscription) doClose() error {
+	if s.sub == nil {
+		return nil
+	}
+
+	err := s.sub.Unsubscribe()
+
+	clear(s.listeners)
+	s.sub = nil
+
+	return err
+}
+
+func (s *natsSubscription) subscribe(listener AsyncEventListener) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, found := s.listeners[listener]; found {
+		return ErrAlreadyRegistered
+	}
+
+	s.listeners[listener] = true
+	return nil
+}
+
+func (s *natsSubscription) unsubscribe(listener AsyncEventListener) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.listeners, listener)
+	if len(s.listeners) > 0 {
+		// Still used
+		return nil
+	}
+
+	return s.doClose()
+}
+
+type asyncEventsNatsSubscriptions map[string]*natsSubscription
 
 type asyncEventsNats struct {
 	mu     sync.Mutex
@@ -124,11 +200,9 @@ func (e *asyncEventsNats) GetServerInfoNats() *talk.BackendServerInfoNats {
 func closeSubscriptions(logger log.Logger, wg *sync.WaitGroup, subscriptions asyncEventsNatsSubscriptions) {
 	defer wg.Done()
 
-	for subject, subs := range subscriptions {
-		for _, sub := range subs {
-			if err := sub.Unsubscribe(); err != nil && !errors.Is(err, nats.ErrConnectionClosed) {
-				logger.Printf("Error unsubscribing %s: %s", subject, err)
-			}
+	for subject, sub := range subscriptions {
+		if err := sub.close(); err != nil && !errors.Is(err, nats.ErrConnectionClosed) {
+			logger.Printf("Error unsubscribing %s: %s", subject, err)
 		}
 	}
 }
@@ -158,19 +232,24 @@ func (e *asyncEventsNats) Close(ctx context.Context) error {
 // +checklocks:e.mu
 func (e *asyncEventsNats) registerListener(key string, subscriptions asyncEventsNatsSubscriptions, listener AsyncEventListener) error {
 	subs, found := subscriptions[key]
-	if !found {
-		subs = make(map[AsyncEventListener]nats.Subscription)
-		subscriptions[key] = subs
-	} else if _, found := subs[listener]; found {
-		return ErrAlreadyRegistered
+	if found {
+		return subs.subscribe(listener)
 	}
 
-	sub, err := e.client.Subscribe(key, listener.AsyncChannel())
+	subs = &natsSubscription{
+		logger: e.logger,
+		listeners: map[AsyncEventListener]bool{
+			listener: true,
+		},
+	}
+
+	sub, err := e.client.Subscribe(key, subs.sendMessage)
 	if err != nil {
 		return err
 	}
 
-	subs[listener] = sub
+	subs.sub = sub
+	subscriptions[key] = subs
 	return nil
 }
 
@@ -181,17 +260,11 @@ func (e *asyncEventsNats) unregisterListener(key string, subscriptions asyncEven
 		return nil
 	}
 
-	sub, found := subs[listener]
-	if !found {
-		return nil
-	}
-
-	delete(subs, listener)
-	if len(subs) == 0 {
+	err := subs.unsubscribe(listener)
+	if subs.empty() {
 		delete(subscriptions, key)
 	}
-
-	return sub.Unsubscribe()
+	return err
 }
 
 func (e *asyncEventsNats) RegisterBackendRoomListener(roomId string, backend *talk.Backend, listener AsyncEventListener) error {

--- a/async/events/async_events_test.go
+++ b/async/events/async_events_test.go
@@ -52,11 +52,35 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		assert.NoError(events.Close(ctx))
+		if ne, ok := events.(*asyncEventsNats); ok {
+			ne.mu.Lock()
+			assert.NotEmpty(ne.backendRoomSubscriptions)
+			assert.NotEmpty(ne.roomSubscriptions)
+			assert.NotEmpty(ne.userSubscriptions)
+			assert.NotEmpty(ne.sessionSubscriptions)
+			ne.mu.Unlock()
+		}
+
+		if assert.NoError(events.Close(ctx)) {
+			if ne, ok := events.(*asyncEventsNats); ok {
+				ne.mu.Lock()
+				assert.Empty(ne.backendRoomSubscriptions)
+				assert.Empty(ne.roomSubscriptions)
+				assert.Empty(ne.userSubscriptions)
+				assert.Empty(ne.sessionSubscriptions)
+				ne.mu.Unlock()
+			}
+		}
 	})
 
 	listener := &TestBackendRoomListener{
 		events: make(AsyncChannel, 1),
+	}
+	listener2 := &TestBackendRoomListener{
+		events: make(AsyncChannel, 1),
+	}
+	slowListener := &TestBackendRoomListener{
+		events: make(AsyncChannel),
 	}
 
 	roomId := "1234"
@@ -64,6 +88,15 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 	require.NoError(events.RegisterBackendRoomListener(roomId, backend, listener))
 	defer func() {
 		assert.NoError(events.UnregisterBackendRoomListener(roomId, backend, listener))
+	}()
+	assert.ErrorIs(events.RegisterBackendRoomListener(roomId, backend, listener), ErrAlreadyRegistered)
+	require.NoError(events.RegisterBackendRoomListener(roomId, backend, listener2))
+	defer func() {
+		assert.NoError(events.UnregisterBackendRoomListener(roomId, backend, listener2))
+	}()
+	require.NoError(events.RegisterBackendRoomListener(roomId, backend, slowListener))
+	defer func() {
+		assert.NoError(events.UnregisterBackendRoomListener(roomId, backend, slowListener))
 	}()
 
 	msg := &AsyncMessage{
@@ -80,11 +113,30 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 			receivedMsg.SendTime = msg.SendTime
 			assert.Equal(msg, &receivedMsg)
 		}
+
+		received2 := <-listener2.events
+		var received2Msg AsyncMessage
+		if assert.NoError(nats.Decode(received2, &received2Msg)) {
+			assert.True(msg.SendTime.Equal(received2Msg.SendTime), "send times don't match, expected %s, got %s", msg.SendTime, received2Msg.SendTime)
+			received2Msg.SendTime = msg.SendTime
+			assert.Equal(msg, &received2Msg)
+		}
+		select {
+		case msg := <-slowListener.events:
+			assert.Fail("should not have received message", "got %+v", msg)
+		default:
+			// Expected, the slow listener was skipped.
+		}
 	}
 
 	require.NoError(events.RegisterRoomListener(roomId, backend, listener))
 	defer func() {
 		assert.NoError(events.UnregisterRoomListener(roomId, backend, listener))
+	}()
+	assert.ErrorIs(events.RegisterRoomListener(roomId, backend, listener), ErrAlreadyRegistered)
+	require.NoError(events.RegisterRoomListener(roomId, backend, listener2))
+	defer func() {
+		assert.NoError(events.UnregisterRoomListener(roomId, backend, listener2))
 	}()
 
 	roomMessage := &AsyncMessage{
@@ -101,6 +153,14 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 			receivedMsg.SendTime = roomMessage.SendTime
 			assert.Equal(roomMessage, &receivedMsg)
 		}
+
+		received2 := <-listener2.events
+		var received2Msg AsyncMessage
+		if assert.NoError(nats.Decode(received2, &received2Msg)) {
+			assert.True(roomMessage.SendTime.Equal(received2Msg.SendTime), "send times don't match, expected %s, got %s", roomMessage.SendTime, received2Msg.SendTime)
+			received2Msg.SendTime = roomMessage.SendTime
+			assert.Equal(roomMessage, &received2Msg)
+		}
 	}
 
 	userId := "the-user"
@@ -108,6 +168,7 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 	defer func() {
 		assert.NoError(events.UnregisterUserListener(userId, backend, listener))
 	}()
+	assert.ErrorIs(events.RegisterUserListener(userId, backend, listener), ErrAlreadyRegistered)
 
 	userMessage := &AsyncMessage{
 		Type: "room",
@@ -130,6 +191,7 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 	defer func() {
 		assert.NoError(events.UnregisterSessionListener(sessionId, backend, listener))
 	}()
+	assert.ErrorIs(events.RegisterSessionListener(sessionId, backend, listener), ErrAlreadyRegistered)
 
 	sessionMessage := &AsyncMessage{
 		Type: "room",
@@ -146,6 +208,15 @@ func testAsyncEvents(t *testing.T, events AsyncEvents) {
 			assert.Equal(sessionMessage, &receivedMsg)
 		}
 	}
+
+	// Will get cleaned up on close.
+	listener3 := &TestBackendRoomListener{
+		events: make(AsyncChannel, 1),
+	}
+	assert.NoError(events.RegisterBackendRoomListener(roomId+"-other", backend, listener3))
+	assert.NoError(events.RegisterRoomListener(roomId+"-other", backend, listener3))
+	assert.NoError(events.RegisterUserListener(userId+"-other", backend, listener3))
+	assert.NoError(events.RegisterSessionListener(sessionId+"-other", backend, listener3))
 }
 
 func TestAsyncEvents_Loopback(t *testing.T) {

--- a/nats/client.go
+++ b/nats/client.go
@@ -51,6 +51,8 @@ var (
 
 type Msg = nats.Msg
 
+type MsgHandler func(msg *Msg)
+
 type Subscription interface {
 	Unsubscribe() error
 }
@@ -58,7 +60,7 @@ type Subscription interface {
 type Client interface {
 	Close(ctx context.Context) error
 
-	Subscribe(subject string, ch chan *Msg) (Subscription, error)
+	Subscribe(subject string, cb MsgHandler) (Subscription, error)
 	Publish(subject string, message any) error
 }
 

--- a/nats/loopback.go
+++ b/nats/loopback.go
@@ -93,18 +93,14 @@ func (c *LoopbackClient) processMessage(msg *Msg) {
 		return
 	}
 
-	channels := make([]chan *Msg, 0, len(subs))
+	callbacks := make([]MsgHandler, 0, len(subs))
 	for sub := range subs {
-		channels = append(channels, sub.ch)
+		callbacks = append(callbacks, sub.cb)
 	}
 	c.mu.Unlock()
 	defer c.mu.Lock()
-	for _, ch := range channels {
-		select {
-		case ch <- msg:
-		default:
-			c.logger.Printf("Slow consumer %s, dropping message", msg.Subject)
-		}
+	for _, cb := range callbacks {
+		cb(msg)
 	}
 }
 
@@ -131,7 +127,7 @@ type loopbackSubscription struct {
 	subject string
 	client  *LoopbackClient
 
-	ch chan *Msg
+	cb MsgHandler
 }
 
 func (s *loopbackSubscription) Unsubscribe() error {
@@ -139,7 +135,7 @@ func (s *loopbackSubscription) Unsubscribe() error {
 	return nil
 }
 
-func (c *LoopbackClient) Subscribe(subject string, ch chan *Msg) (Subscription, error) {
+func (c *LoopbackClient) Subscribe(subject string, cb MsgHandler) (Subscription, error) {
 	if strings.HasSuffix(subject, ".") || strings.Contains(subject, " ") {
 		return nil, nats.ErrBadSubject
 	}
@@ -153,7 +149,7 @@ func (c *LoopbackClient) Subscribe(subject string, ch chan *Msg) (Subscription, 
 	s := &loopbackSubscription{
 		subject: subject,
 		client:  c,
-		ch:      ch,
+		cb:      cb,
 	}
 	subs, found := c.subscriptions[subject]
 	if !found {

--- a/nats/native.go
+++ b/nats/native.go
@@ -92,8 +92,8 @@ func (c *NativeClient) onReconnected(conn *nats.Conn) {
 	c.logger.Printf("NATS client reconnected to %s (%s)", conn.ConnectedUrl(), conn.ConnectedServerId())
 }
 
-func (c *NativeClient) Subscribe(subject string, ch chan *Msg) (Subscription, error) {
-	return c.conn.ChanSubscribe(subject, ch)
+func (c *NativeClient) Subscribe(subject string, cb MsgHandler) (Subscription, error) {
+	return c.conn.Subscribe(subject, nats.MsgHandler(cb))
 }
 
 func (c *NativeClient) Publish(subject string, message any) error {

--- a/nats/native_test.go
+++ b/nats/native_test.go
@@ -76,7 +76,9 @@ func testClient_Subscribe(t *testing.T, client Client) {
 	require := require.New(t)
 	assert := assert.New(t)
 	dest := make(chan *Msg)
-	sub, err := client.Subscribe("foo", dest)
+	sub, err := client.Subscribe("foo", func(msg *Msg) {
+		dest <- msg
+	})
 	require.NoError(err)
 	ch := make(chan struct{})
 
@@ -139,8 +141,7 @@ func TestClient_PublishAfterClose(t *testing.T) { // nolint:paralleltest
 func testClient_SubscribeAfterClose(t *testing.T, client Client) {
 	assert.NoError(t, client.Close(t.Context()))
 
-	ch := make(chan *Msg)
-	_, err := client.Subscribe("foo", ch)
+	_, err := client.Subscribe("foo", func(msg *Msg) {})
 	assert.ErrorIs(t, err, nats.ErrConnectionClosed)
 }
 
@@ -159,9 +160,8 @@ func testClient_BadSubjects(t *testing.T, client Client) {
 		"foo.",
 	}
 
-	ch := make(chan *Msg)
 	for _, s := range subjects {
-		_, err := client.Subscribe(s, ch)
+		_, err := client.Subscribe(s, func(msg *Msg) {})
 		assert.ErrorIs(err, nats.ErrBadSubject, "Expected error for subject %s", s)
 	}
 }

--- a/nats/test/server_test.go
+++ b/nats/test/server_test.go
@@ -65,8 +65,7 @@ func TestWaitForSubscriptionsEmpty(t *testing.T) {
 		assert.NoError(client.Close(context.Background()))
 	}()
 
-	ch := make(chan *nats.Msg)
-	sub, err := client.Subscribe("foo", ch)
+	sub, err := client.Subscribe("foo", func(msg *nats.Msg) {})
 	require.NoError(err)
 
 	ready := make(chan struct{})


### PR DESCRIPTION
This saves a lot of (room) subscriptions for sessions in the same room.